### PR TITLE
feat(xor-url): add support for XOR-URL using CID

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -42,14 +42,14 @@ struct CmdArgs {
     dry: bool,
     /// Base encoding to be used for XOR-URLs generated. Currently supported: base32 (default) and base32z
     #[structopt(long = "xorurl", raw(global = "true"))]
-    xor_url_base: Option<String>,
+    xorurl_base: Option<String>,
 }
 
 pub fn run() -> Result<(), String> {
     // Let's first get all the arguments passed in
     let args = CmdArgs::from_args();
 
-    let mut safe = Safe::new(args.xor_url_base.clone().unwrap_or("".to_string()));
+    let mut safe = Safe::new(args.xorurl_base.clone().unwrap_or("".to_string()));
 
     debug!("Processing command: {:?}", args);
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,13 +40,16 @@ struct CmdArgs {
     /// Dry run of command. No data will be written. No coins spent.
     #[structopt(long = "dry-run", raw(global = "true"))]
     dry: bool,
+    /// Base encoding to be used for XOR-URLs generated. Currently supported: base32 (default) and base32z
+    #[structopt(long = "xorurl", raw(global = "true"))]
+    xor_url_base: Option<String>,
 }
 
 pub fn run() -> Result<(), String> {
     // Let's first get all the arguments passed in
     let args = CmdArgs::from_args();
 
-    let mut safe = Safe::new();
+    let mut safe = Safe::new(args.xor_url_base.clone().unwrap_or("".to_string()));
 
     debug!("Processing command: {:?}", args);
 

--- a/src/lib_helpers.rs
+++ b/src/lib_helpers.rs
@@ -133,28 +133,28 @@ fn temp_multihash_encode(hash: multihash::Hash, digest: &[u8]) -> Result<Vec<u8>
 }
 
 #[test]
-fn test_xor_url_base32_encoding() {
+fn test_xorurl_base32_encoding() {
     let xorname: XorName = *b"12345678901234567890123456789012";
-    let xor_url = xorname_to_xorurl(&xorname, &"base32".to_string());
+    let xorurl = xorname_to_xorurl(&xorname, &"base32".to_string());
     let base32_xorurl = "safe://bbkulcamjsgm2dknrxha4tamjsgm2dknrxha4tamjsgm2dknrxha4tamjs";
-    assert_eq!(xor_url, base32_xorurl);
+    assert_eq!(xorurl, base32_xorurl);
 
-    let xor_url = xorname_to_xorurl(&xorname, &"".to_string());
-    assert_eq!(xor_url, base32_xorurl);
+    let xorurl = xorname_to_xorurl(&xorname, &"".to_string());
+    assert_eq!(xorurl, base32_xorurl);
 }
 
 #[test]
-fn test_xor_url_base32z_encoding() {
+fn test_xorurl_base32z_encoding() {
     let xorname: XorName = *b"12345678901234567890123456789012";
-    let xor_url = xorname_to_xorurl(&xorname, &"base32z".to_string());
+    let xorurl = xorname_to_xorurl(&xorname, &"base32z".to_string());
     let base32_xorurl = "safe://hbkwmnycj1gc4dkptz8yhuycj1gc4dkptz8yhuycj1gc4dkptz8yhuycj1";
-    assert_eq!(xor_url, base32_xorurl);
+    assert_eq!(xorurl, base32_xorurl);
 }
 
 #[test]
-fn test_xor_url_decoding() {
+fn test_xorurl_decoding() {
     let xorname: XorName = *b"12345678901234567890123456789012";
-    let xor_url = xorname_to_xorurl(&xorname, &"base32".to_string());
-    let decoded_xorname = xorurl_to_xorname(&xor_url);
+    let xorurl = xorname_to_xorurl(&xorname, &"base32".to_string());
+    let decoded_xorname = xorurl_to_xorname(&xorurl);
     assert_eq!(xorname, decoded_xorname);
 }

--- a/src/subcommands/keys.rs
+++ b/src/subcommands/keys.rs
@@ -6,9 +6,9 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::subcommands::helpers::{get_target_location, prompt_user};
 use log::warn;
 use safe_cli::{BlsKeyPair, Safe};
-use crate::subcommands::helpers::{get_target_location, prompt_user};
 use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]

--- a/src/subcommands/keys.rs
+++ b/src/subcommands/keys.rs
@@ -88,16 +88,16 @@ pub fn create_new_key(
         // '--from' is either a Wallet XOR-URL, a Key XOR-URL, or a pk
         // TODO: support Key XOR-URL and pk, we now support only Key XOR-URL
         // Prompt the user for the secret key since 'from' is a Key and not a Wallet
-        let from_xor_url = from.expect("Missing the 'from' argument");
+        let from_xorurl = from.expect("Missing the 'from' argument");
         let sk = prompt_user(
             &format!(
                 "Enter secret key corresponding to public key at XOR-URL \"{}\": ",
-                from_xor_url
+                from_xorurl
             ),
             "Invalid input",
         );
 
-        let pk_from_xor = safe.keys_fetch_pk(&from_xor_url, &sk);
+        let pk_from_xor = safe.keys_fetch_pk(&from_xorurl, &sk);
         let from_key_pair = BlsKeyPair {
             pk: pk_from_xor,
             sk,


### PR DESCRIPTION
Also allow base32 (default) and base32z encoding to be chosen by the user, e.g.:
```
$ safe keys create --test-coins --xor-url base32z
Note that the Key to be created will be preloaded with **test coins** rather than real coins
You must pass a preload amount with test-coins, 1000.111 will be added
New Key created at XOR-URL: "safe://hbkwmnbefby6w8dzqkenwh9imryt4nnck47uy7dggzjqnyozgwgdpqamz4"
Key pair generated: pk="a0a107a871ddca40a9cfd564047421315aecc1d198d74b84085cd430daec2efadd29f1fdf81ac16e1671980e7b3232f4", sk="f90bcb6e386fc7c3dc3e8a40f2dd1a677670d975be30fb05429bd4cb1101ba3a"
```

If the provided base is not supported is uses the default:
```
$ cargo run -- keys create --test-coins --xorurl base64
Note that the Key to be created will be preloaded with **test coins** rather than real coins
You must pass a preload amount with test-coins, 1000.111 will be added
Base encoding 'base64' not supported for XOR-URL. Using default 'base32'.
New Key created at XOR-URL: "safe://bbkulcblpuelwirijnieunkbhqmsqcrv5cagtfaovcwgsdsue5dtecbzks"
Key pair generated: pk="adf422ec88a12d4128d504f064a028d7a201a6503aa2b1a439509d1cc820e552cb657abdaaf89211fd3763be8c1d0267", sk="ffb186c39db8d94e9ccf09791255890bb9ae246742e6bb1e4c75182419333b48"
```