### PR TITLE
refactor(files): enhancements to error messages and to how errors are reported for files

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ $ safe wallet transfer <amount> <to> <from>
 E.g.:
 ```shell
 $ safe wallet transfer 323.23 safe://7e0ae5e6ed15a8065ea03218a0903b0be7c9d78384998817331b309e9d23566e safe://6221785c1a20163bbefaf523af15fa525d83b00be7502d28cae5b09ac54f4e75
-Transaction Success. Tx_id: 44dcd919-0703-4f23-a9a2-6b6be8da0bcc
+Success. TX_ID: 44dcd919-0703-4f23-a9a2-6b6be8da0bcc
 ```
 
 ### Files
@@ -384,7 +384,7 @@ FilesContainer created at: "safe://hbyiapu9fyfh49jansx6jsoqnb76jed1jbawfrz5awmbw
 We can then use `safe cat` command with the XOR-URL of the `FilesContainer` just created to render the list of files linked from it:
 ```shell
 $ safe cat safe://hbyiapu9fyfh49jansx6jsoqnb76jed1jbawfrz5awmbw7yw7f6i1uqj5w
-Files of FilesContainer at: "safe://hbyiapu9fyfh49jansx6jsoqnb76jed1jbawfrz5awmbw7yw7f6i1uqj5w"
+Files of FilesContainer (version 1) at "safe://hbyiapu9fyfh49jansx6jsoqnb76jed1jbawfrz5awmbw7yw7f6i1uqj5w":
 +-------------------------+------+-----------------------------------+---------------------------------------------------------------+
 | Name                    | Size | Created                           | Link                                                          |
 +-------------------------+------+-----------------------------------+---------------------------------------------------------------+

--- a/src/api/safe_client_libs.rs
+++ b/src/api/safe_client_libs.rs
@@ -494,13 +494,15 @@ impl SafeApp {
         &self,
         xorurl: &str,
         tag: u64,
-    ) -> Result<BTreeMap<Vec<u8>, MDataValue>, String> {
+    ) -> Result<BTreeMap<Vec<u8>, MDataValue>, &str> {
         let safe_app: &App = match &self.safe_conn {
             Some(app) => &app,
-            None => return Err(APP_NOT_CONNECTED.to_string()),
+            None => return Err(APP_NOT_CONNECTED),
         };
 
-        let xorname = XorUrlEncoder::from_url(xorurl)?.xorname();
+        let xorname = XorUrlEncoder::from_url(xorurl)
+            .map_err(|_| "InvalidXorUrl")?
+            .xorname();
         let entries = unwrap!(run(safe_app, move |client, _app_context| {
             client
                 .list_seq_mdata_entries(xorname, tag)

--- a/src/api/scl_mock.rs
+++ b/src/api/scl_mock.rs
@@ -352,7 +352,7 @@ impl SafeApp {
         Ok(xorname)
     }
 
-    fn get_seq_mdata(&self, xorname: &XorName, _tag: u64) -> Result<SeqMutableDataMock, String> {
+    fn get_seq_mdata(&self, xorname: &XorName, _tag: u64) -> Result<SeqMutableDataMock, &str> {
         debug!(
             "attempting to locate scl mock mdata: {:?}",
             &xorname_to_hex(&xorname)
@@ -360,7 +360,7 @@ impl SafeApp {
 
         match self.mock_data.mutable_data.get(&xorname_to_hex(&xorname)) {
             Some(seq_md) => Ok(seq_md.clone()),
-            None => Err("SeqMutableDataNotFound".to_string()),
+            None => Err("SeqMutableDataNotFound"),
         }
     }
 
@@ -410,9 +410,9 @@ impl SafeApp {
         &self,
         xorurl: &str,
         tag: u64,
-    ) -> Result<BTreeMap<Vec<u8>, MDataValue>, String> {
+    ) -> Result<BTreeMap<Vec<u8>, MDataValue>, &str> {
         debug!("Listing seq_mdata_entries for: {}", xorurl);
-        let xorurl_encoder = XorUrlEncoder::from_url(xorurl)?;
+        let xorurl_encoder = XorUrlEncoder::from_url(xorurl).map_err(|_| "InvalidXorUrl")?;
         let seq_md = self.get_seq_mdata(&xorurl_encoder.xorname(), tag)?;
 
         let mut res = BTreeMap::new();

--- a/src/api/wallet.rs
+++ b/src/api/wallet.rs
@@ -91,9 +91,17 @@ impl Safe {
         debug!("Finding total wallet balance for: {:?}", xorurl);
         let mut total_balance: f64 = 0.0;
         // Let's get the list of balances from the Wallet
-        let spendable_balances = self
+        let spendable_balances = match self
             .safe_app
-            .list_seq_mdata_entries(xorurl, WALLET_TYPE_TAG)?;
+            .list_seq_mdata_entries(xorurl, WALLET_TYPE_TAG)
+        {
+            Ok(entries) => entries,
+            Err("SeqMutableDataNotFound") => return Err(format!("No Wallet found at {}", xorurl)),
+            Err("InvalidXorUrl") => {
+                return Err("The XOR-URL provided is invalid and cannot be decoded".to_string())
+            }
+            Err(err) => return Err(format!("Failed to read balances from Wallet: {}", err)),
+        };
 
         debug!("Spendable balances: {:?}", spendable_balances);
         // Iterate through the Keys and query the balance for each

--- a/src/subcommands/files.rs
+++ b/src/subcommands/files.rs
@@ -109,23 +109,34 @@ pub fn files_commander(
 
             // Now let's just print out the content of the FilesMap
             if OutputFmt::Pretty == output_fmt {
-                if processed_files.is_empty() {
-                    println!("No changes were required, source location is already in sync with FilesContainer (version {}) at: \"{}\"", version, target);
-                } else {
+                let mut table = Table::new();
+                let format = FormatBuilder::new()
+                    .column_separator(' ')
+                    .padding(0, 1)
+                    .build();
+                table.set_format(format);
+                let mut success_count = 0;
+                for (file_name, (change, link)) in processed_files.iter() {
+                    if change != "E" {
+                        success_count += 1;
+                    }
+                    table.add_row(row![change, file_name, link]);
+                }
+
+                if success_count > 0 {
                     println!(
                         "FilesContainer synced up (version {}): \"{}\"",
                         version, target
                     );
-                    let mut table = Table::new();
-                    let format = FormatBuilder::new()
-                        .column_separator(' ')
-                        .padding(0, 1)
-                        .build();
-                    table.set_format(format);
-                    for (file_name, (change, link)) in processed_files.iter() {
-                        table.add_row(row![change, file_name, link]);
-                    }
                     table.printstd();
+                } else if !processed_files.is_empty() {
+                    println!(
+                        "No changes were made to FilesContainer (version {}) at \"{}\"",
+                        version, target
+                    );
+                    table.printstd();
+                } else {
+                    println!("No changes were required, source location is already in sync with FilesContainer (version {}) at: \"{}\"", version, target);
                 }
             } else {
                 println!(


### PR DESCRIPTION
Fixes #110 
Fixes #121 
Fixes #122 

Also, with this PR errors for individual files are included in the report with "E" sign, e.g.:
```
$ safe files put -r ./tests/testfolder
FilesContainer created at: "safe://hbyz6myh9bcqtpo5y8c1yxenctk8us899kmck8c1mw3badcuazxqfhrj5w"
+  ./tests/testfolder/another.md              safe://hoqc91w6uyj8fq8yj5xaaa549zj7zsqf56jsbo6nfafsd4acx7boaq 
+  ./tests/testfolder/noextension             safe://hoxxtw4cb9zgh9owhoepcmr7foo1jh9rqagagemo3i77i6g5hckecc 
E  ./tests/testfolder/nopermissions           <Failed to read file from local location: Permission denied (os error 13)> 
+  ./tests/testfolder/subfolder/subexists.md  safe://hox749but6yinunqdzsetk17zhf4gqhuaj7o3iojjsd3qgarm3r51m 
+  ./tests/testfolder/test.md                 safe://hoqj991jts9f1hbsynxn49458wo5jzr36pi4koqswkss3pawoogmbc 
```