### PR TITLE
fix(files): remove --set-root arg in favor of using source and dest args

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,11 +324,11 @@ FilesContainer created at: "safe://bbkulca25xhzwo6mcxlji7ocf5tm5hgn2x3mxtg62qzyc
 
 ##### Base path of files in a FilesContainer
 
-When uploading files onto a `FilesContainer` with the CLI, the base path for the files in the container is automatically calculated. All the paths at the source are compared and any common base path found among them is used as the root path, and the files are published on the `FilesContainer` with an absolute path based on the calculated root path.
+When uploading files onto a `FilesContainer` with the CLI, the base path for the files in the container is set by default to be `/`. All the files at the source are published on the `FilesContainer` with an absolute path with base `/` path.
 
 As an example, if we upload three files, which at source are located at `/to-upload/file1.txt`, `/to-upload/myfolder/file2.txt`, and `/to-upload/myotherfolder/subfolder/file3.txt`, the files will be published on the `FilesContainer` with paths `/file1.txt`, `/myfolder/file2.txt`, and `/myotherfolder/subfolder/file3.txt` respectively.
 
-We can additionally use the `--set-root` argument to set a root path which will be prefixed to each of the paths in the `FilesContainer`, e.g. if we provide `--set-root /mychosenroot` argument to the `files put` command when uploading the above files, they will be published on the `FilesContainer` with paths `/mychosenroot/file1.txt`, `/mychosenroot/myfolder/file2.txt`, and `/mychosenroot/myotherfolder/subfolder/file3.txt` respectively. This can be verified by querying the `FilesContainer` content with the `safe cat` command, please see further below for details of how this command.
+We can additionally pass a destination path argument to set a base path for each of the paths in the `FilesContainer`, e.g. if we provide `/mychosenroot/` destination path argument to the `files put` command when uploading the above files, they will be published on the `FilesContainer` with paths `/mychosenroot/file1.txt`, `/mychosenroot/myfolder/file2.txt`, and `/mychosenroot/myotherfolder/subfolder/file3.txt` respectively. This can be verified by querying the `FilesContainer` content with the `safe cat` command, please see further below for details of how this command.
 
 #### Files Sync
 
@@ -362,6 +362,15 @@ FilesContainer synced up (version 2): "safe://hbyw8kkqr3tcwfqiiqh4qeaehzr1e9boiu
 The `*`, `+` and `-` signs mean that the files were updated, added, and removed respectively.
 
 Also, please note we provided the optional `--delete` flag to the command above, this forces the deletion of those files which are found at the targeted `FilesContainer` that are not found in the source location, like the case of `./to-upload/test.md` file in our example above. If we didn't provide such flag, only the modification and creation of files would have been updated on the `FilesContainer`, like the case of `./to-upload/another.md` and `./to-upload/new` files in our example above.
+
+The `files sync` command also supports to be passed a destination path as the `files put` command, but in this case the destination path needs to be provided as part of the target XOR-URL. E.g., we can sync a `FilesContainer` using the local path and provide a specific destination path `new-files` in the target XOR-URL:
+```shell
+$ safe files sync ./other-folder/ safe://hbyw8kkqr3tcwfqiiqh4qeaehzr1e9boiuyfw5bqqx1adyh9sawdhboj5w/new-files
+FilesContainer synced up (version 3): "safe://hbyw8kkqr3tcwfqiiqh4qeaehzr1e9boiuyfw5bqqx1adyh9sawdhboj5w"
++  ./other-folder/file1.txt     safe://hoqi7papyp7c6riyxiez6y5fh5ugj4xc7syqhmex774ws4g4b1z1xq
+```
+
+The `./other-folder/file1.txt` file will be uploaded and published in the `FilesContainer` with path `/new-files/file1.txt`.
 
 #### Cat
 

--- a/src/api/fetch.rs
+++ b/src/api/fetch.rs
@@ -50,7 +50,7 @@ impl Safe {
     /// # use unwrap::unwrap;
     /// # use std::collections::BTreeMap;
     /// # let mut safe = Safe::new("base32z".to_string());
-    /// let (xorurl, _, _) = unwrap!(safe.files_container_create("tests/testfolder/", true, None));
+    /// let (xorurl, _, _) = unwrap!(safe.files_container_create("tests/testfolder/", None, true));
     ///
     /// let safe_data = unwrap!( safe.fetch( &format!( "{}/test.md", &xorurl ) ) );
     /// let data_string = match safe_data {
@@ -181,7 +181,7 @@ fn test_fetch_files_container() {
     safe.connect("", "").unwrap();
 
     let (xorurl, _, files_map) =
-        unwrap!(safe.files_container_create("tests/testfolder", true, None));
+        unwrap!(safe.files_container_create("tests/testfolder", None, true));
 
     let xorurl_encoder = unwrap!(XorUrlEncoder::from_url(&xorurl));
     let content = unwrap!(safe.fetch(&xorurl));

--- a/src/subcommands/files.rs
+++ b/src/subcommands/files.rs
@@ -32,24 +32,22 @@ pub enum FilesSubCommands {
     Put {
         /// The source file/folder local path
         location: String,
+        /// The destination path (in the FilesContainer) for the uploaded files and folders (default is '/')
+        dest: Option<String>,
         /// Recursively upload folders and files found in the source location
         #[structopt(short = "r", long = "recursive")]
         recursive: bool,
-        #[structopt(long = "set-root")]
-        set_root: Option<String>,
     },
     #[structopt(name = "sync")]
     /// Sync files to the network
     Sync {
         /// The soure location
         location: String,
-        /// The target FilesContainer to sync up source files with
+        /// The target FilesContainer to sync up source files with, optionally including the destination path (default is '/')
         target: Option<String>,
         /// Recursively sync folders and files found in the source location
         #[structopt(short = "r", long = "recursive")]
         recursive: bool,
-        #[structopt(long = "set-root")]
-        set_root: Option<String>,
         /// Delete files found at the target FilesContainer that are not in the source location
         #[structopt(short = "d", long = "delete")]
         delete: bool,
@@ -64,12 +62,12 @@ pub fn files_commander(
     match cmd {
         Some(FilesSubCommands::Put {
             location,
+            dest,
             recursive,
-            set_root,
         }) => {
             // create FilesContainer from a given path to local files/folders
             let (files_container_xorurl, processed_files, _files_map) =
-                safe.files_container_create(&location, recursive, set_root)?;
+                safe.files_container_create(&location, dest, recursive)?;
 
             // Now let's just print out the content of the FilesMap
             if OutputFmt::Pretty == output_fmt {
@@ -98,14 +96,13 @@ pub fn files_commander(
             location,
             target,
             recursive,
-            set_root,
             delete,
         }) => {
             let target = get_target_location(target)?;
 
             // Update the FilesContainer on the Network
             let (version, processed_files, _files_map) =
-                safe.files_container_sync(&location, &target, recursive, set_root, delete)?;
+                safe.files_container_sync(&location, &target, recursive, delete)?;
 
             // Now let's just print out the content of the FilesMap
             if OutputFmt::Pretty == output_fmt {

--- a/tests/cli_files.rs
+++ b/tests/cli_files.rs
@@ -58,15 +58,14 @@ fn calling_safe_files_put_recursive() {
 }
 
 #[test]
-fn calling_safe_files_put_recursive_and_change_root() {
+fn calling_safe_files_put_recursive_and_set_dest_path() {
     let files_container = cmd!(
         get_bin_location(),
         "files",
         "put",
         TEST_FOLDER,
+        "/aha",
         "--recursive",
-        "--set-root",
-        "aha",
     )
     .read()
     .unwrap();
@@ -199,10 +198,7 @@ fn calling_safe_files_sync() {
     .read()
     .unwrap();
 
-    let file = format!(
-        "{}/tests/testfolder/subfolder/subexists.md",
-        files_container_xor
-    );
+    let file = format!("{}/subexists.md", files_container_xor);
     let synced_file_cat = cmd!(get_bin_location(), "cat", &file).read().unwrap();
     assert_eq!(synced_file_cat, "the sub");
 }


### PR DESCRIPTION
Trailing slash in source and destination paths are now taken into account to realise the final destination path, both for files put and sync commands.

Fixes #134