### PR TITLE
feat(files): allow files sync --delete only with --recursive

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,12 +56,12 @@ stage('deploy') {
 }
 
 def runTests() {
-    command = "RANDOM_PORT_NUMBER=\$(( \$RANDOM % 100 + 41800 )) "
+    command_prefix = "RANDOM_PORT_NUMBER=\$(( \$RANDOM % 100 + 41800 )) "
     try {
-        test_command = command + "make test"
+        test_command = command_prefix + "make test"
         sh(test_command)
     } finally {
-        clean_command = command + "make clean"
+        clean_command = command_prefix + "make clean"
         sh(clean_command)
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ stage('build & test') {
     parallel linux: {
         node('docker') {
             checkout(scm)
-            sh("make test")
+            runTests()
             packageBuildArtifacts('linux')
             uploadBuildArtifacts()
         }
@@ -17,7 +17,7 @@ stage('build & test') {
     windows: {
         node('windows') {
             checkout(scm)
-            sh("make test")
+            runTests()
             packageBuildArtifacts('windows')
             uploadBuildArtifacts()
         }
@@ -25,7 +25,7 @@ stage('build & test') {
     macos: {
         node('osx') {
             checkout(scm)
-            sh("make test")
+            runTests()
             packageBuildArtifacts('macos')
             uploadBuildArtifacts()
         }
@@ -52,6 +52,17 @@ stage('deploy') {
         } else {
             echo("${env.BRANCH_NAME} does not match the deployment branch. Nothing to do.")
         }
+    }
+}
+
+def runTests() {
+    command = "RANDOM_PORT_NUMBER=\$(( \$RANDOM % 100 + 41800 )) "
+    try {
+        test_command = command + "make test"
+        sh(test_command)
+    } finally {
+        clean_command = command + "make clean"
+        sh(clean_command)
     }
 }
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build-container:
 push-container:
 	docker push maidsafe/safe-cli-build:${SAFE_CLI_VERSION}
 
-test:
+test: clean
 	rm -rf artifacts
 	mkdir artifacts
 ifeq ($(UNAME_S),Linux)
@@ -75,6 +75,16 @@ endif
 	rm ${SAFE_CLI_BRANCH}-${SAFE_CLI_BUILD_NUMBER}-safe_cli-linux-x86_64.tar.gz
 	rm ${SAFE_CLI_BRANCH}-${SAFE_CLI_BUILD_NUMBER}-safe_cli-windows-x86_64.tar.gz
 	rm ${SAFE_CLI_BRANCH}-${SAFE_CLI_BUILD_NUMBER}-safe_cli-macos-x86_64.tar.gz
+
+clean:
+# Both taskkill and killall could be called when safe_auth isn't running.
+# The behaviour of both is to error if there are no processes that match the name,
+# so we can just pipe it through || true to ignore that error and continue.
+ifeq ($(OS),Windows_NT)
+    cmd.exe /c "taskkill /F /IM safe_auth.exe" || true
+else ifeq ($(UNAME_S),Darwin)
+    lsof -t -i tcp:${RANDOM_PORT_NUMBER} | xargs -n 1 -x kill
+endif
 
 package-commit_hash-artifacts-for-deploy:
 	rm -f *.tar

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build-container:
 push-container:
 	docker push maidsafe/safe-cli-build:${SAFE_CLI_VERSION}
 
-test: clean
+test:
 	rm -rf artifacts
 	mkdir artifacts
 ifeq ($(UNAME_S),Linux)
@@ -81,9 +81,10 @@ clean:
 # The behaviour of both is to error if there are no processes that match the name,
 # so we can just pipe it through || true to ignore that error and continue.
 ifeq ($(OS),Windows_NT)
-    cmd.exe /c "taskkill /F /IM safe_auth.exe" || true
+	cmd.exe /c "taskkill /F /IM safe_auth.exe" || true
 else ifeq ($(UNAME_S),Darwin)
-    lsof -t -i tcp:${RANDOM_PORT_NUMBER} | xargs -n 1 -x kill
+	lsof -t -i tcp:${RANDOM_PORT_NUMBER} | xargs -n 1 -x kill
+	rm -rf ~/safe_auth-${RANDOM_PORT_NUMBER}
 endif
 
 package-commit_hash-artifacts-for-deploy:

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ FilesContainer synced up (version 2): "safe://hbyw8kkqr3tcwfqiiqh4qeaehzr1e9boiu
 
 The `*`, `+` and `-` signs mean that the files were updated, added, and removed respectively.
 
-Also, please note we provided the optional `--delete` flag to the command above, this forces the deletion of those files which are found at the targeted `FilesContainer` that are not found in the source location, like the case of `./to-upload/test.md` file in our example above. If we didn't provide such flag, only the modification and creation of files would have been updated on the `FilesContainer`, like the case of `./to-upload/another.md` and `./to-upload/new` files in our example above.
+Also, please note we provided the optional `--delete` flag to the command above, this forces the deletion of those files which are found at the targeted `FilesContainer` that are not found in the source location, like the case of `./to-upload/test.md` file in our example above. If we didn't provide such flag, only the modification and creation of files would have been updated on the `FilesContainer`, like the case of `./to-upload/another.md` and `./to-upload/new` files in our example above. Note that `--delete` is only allowed if the `--recursive` flag is also provided.
 
 The `files sync` command also supports to be passed a destination path as the `files put` command, but in this case the destination path needs to be provided as part of the target XOR-URL. E.g., we can sync a `FilesContainer` using the local path and provide a specific destination path `new-files` in the target XOR-URL:
 ```shell

--- a/resources/test-scripts/all-tests
+++ b/resources/test-scripts/all-tests
@@ -1,6 +1,14 @@
 #!/bin/bash
 
-export SAFE_MOCK_VAULT_PATH=~/safe_auth-$RANDOM_PORT_NUMBER
+if [ -z $RANDOM_PORT_NUMBER ]
+then
+  export RANDOM_PORT_NUMBER=41805
+fi
+
+if [ -z $SAFE_MOCK_VAULT_PATH ]
+then
+  export SAFE_MOCK_VAULT_PATH=~/safe_auth
+fi
 
 function setup_safe_auth() {
     rm -rf $SAFE_MOCK_VAULT_PATH

--- a/resources/test-scripts/all-tests
+++ b/resources/test-scripts/all-tests
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export SAFE_MOCK_VAULT_PATH=~/safe_auth
+export SAFE_MOCK_VAULT_PATH=~/safe_auth-$RANDOM_PORT_NUMBER
 
 function setup_safe_auth() {
     rm -rf $SAFE_MOCK_VAULT_PATH

--- a/resources/test-scripts/all-tests
+++ b/resources/test-scripts/all-tests
@@ -1,18 +1,24 @@
 #!/bin/bash
 
+export SAFE_MOCK_VAULT_PATH=~/safe_auth
+
+function setup_safe_auth() {
+    rm -rf $SAFE_MOCK_VAULT_PATH
+    git clone https://github.com/maidsafe/safe-authenticator-cli.git $SAFE_MOCK_VAULT_PATH
+    (
+        cd $SAFE_MOCK_VAULT_PATH
+        SAFE_AUTH_SECRET=a SAFE_AUTH_PASSWORD=b cargo run --features=mock-network -- -i nonsense || true
+        echo "Launching safe_auth daemon on port:" $RANDOM_PORT_NUMBER
+        SAFE_AUTH_SECRET=a SAFE_AUTH_PASSWORD=b cargo run --features=mock-network -- --daemon $RANDOM_PORT_NUMBER --allow-all-auth &
+        sleep 15
+        cd -
+    )
+}
+
 set -e -x
 
 # first setup auth CLI
-rm -f $TMP/SCL-Mock
-rm -f $TMPDIR/SCL-Mock
-rm -rf ~/safe_auth
-git clone https://github.com/maidsafe/safe-authenticator-cli.git ~/safe_auth
-cd ~/safe_auth
-ls
-SAFE_AUTH_SECRET=a SAFE_AUTH_PASSWORD=b cargo run --features=mock-network -- -i nonsense || true
-SAFE_AUTH_SECRET=a SAFE_AUTH_PASSWORD=b cargo run --features=mock-network -- --daemon 41805 --allow-all-auth &
-sleep 15
-cd -
+setup_safe_auth
 
 # run tests with CLI's own mock
 cargo test --release --features=scl-mock -- --test-threads=1
@@ -25,7 +31,8 @@ cargo test --doc --release --features=mock-network,fake-auth -- --test-threads=1
 
 # now let's run the integration tests but without fake-auth, using the safe_auth CLI to get credentials
 # get auth credentials which will be then used by the integration tests to connect to mock-network
-cargo run --release --features=mock-network -- auth
+echo "Sending auth request to port:" $RANDOM_PORT_NUMBER
+cargo run --release --features=mock-network -- auth --port $RANDOM_PORT_NUMBER
 
 # we can now run each of the integration tests suite
 cargo test --release --features=mock-network --test cli_cat -- --test-threads=1

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -15,8 +15,12 @@ use safe_nd::AppPermissions;
 use std::collections::HashMap;
 use std::io::Read;
 
-// Default URL where to send a GET request to the authenticator webservice for authorising a SAFE app
-const SAFE_AUTH_WEBSERVICE_BASE_URL: &str = "http://localhost:41805/authorise/";
+// Default host where to send a GET request to the authenticator webservice for authorising a SAFE app
+const SAFE_AUTH_ENDPOINT_HOST: &str = "http://localhost";
+// Default port number where to send a GET request for authorising the CLI app
+const SAFE_AUTH_ENDPOINT_PORT: u16 = 41805;
+// Path where the authenticator webservice endpoint
+const SAFE_AUTH_ENDPOINT_PATH: &str = "authorise/";
 
 #[allow(dead_code)]
 impl Safe {
@@ -27,6 +31,7 @@ impl Safe {
         app_id: &str,
         app_name: &str,
         app_vendor: &str,
+        port: Option<u16>,
     ) -> ResultReturn<String> {
         info!("Sending authorisation request to SAFE Authenticator...");
 
@@ -58,8 +63,11 @@ impl Safe {
             auth_req_str
         );
 
-        let authenticator_webservice_url =
-            SAFE_AUTH_WEBSERVICE_BASE_URL.to_string() + &auth_req_str;
+        let port_number = port.unwrap_or(SAFE_AUTH_ENDPOINT_PORT);
+        let authenticator_webservice_url = format!(
+            "{}:{}/{}{}",
+            SAFE_AUTH_ENDPOINT_HOST, port_number, SAFE_AUTH_ENDPOINT_PATH, auth_req_str
+        );
         let mut res = httpget(&authenticator_webservice_url).map_err(|err| {
             Error::AuthError(format!("Failed to send request to Authenticator: {}", err))
         })?;

--- a/src/api/fetch.rs
+++ b/src/api/fetch.rs
@@ -51,7 +51,7 @@ impl Safe {
     /// # use std::collections::BTreeMap;
     /// # let mut safe = Safe::new("base32z".to_string());
     /// # unwrap!(safe.connect("", Some("fake-credentials")));
-    /// let (xorurl, _, _) = unwrap!(safe.files_container_create("tests/testfolder/", None, true));
+    /// let (xorurl, _, _) = unwrap!(safe.files_container_create("tests/testfolder/", None, true, false));
     ///
     /// let safe_data = unwrap!( safe.fetch( &format!( "{}/test.md", &xorurl ) ) );
     /// let data_string = match safe_data {
@@ -192,7 +192,7 @@ fn test_fetch_files_container() {
     safe.connect("", Some("")).unwrap();
 
     let (xorurl, _, files_map) =
-        unwrap!(safe.files_container_create("tests/testfolder", None, true));
+        unwrap!(safe.files_container_create("tests/testfolder", None, true, false));
 
     let xorurl_encoder = unwrap!(XorUrlEncoder::from_url(&xorurl));
     let content = unwrap!(safe.fetch(&xorurl));

--- a/src/api/scl_mock.rs
+++ b/src/api/scl_mock.rs
@@ -46,6 +46,7 @@ struct MockData {
     published_immutable_data: BTreeMap<XorNameStr, Vec<u8>>,
 }
 
+#[derive(Default)]
 pub struct SafeApp {
     mock_data: MockData,
 }
@@ -348,6 +349,7 @@ impl SafeApp {
         }
     }
 
+    #[allow(dead_code)]
     pub fn get_current_seq_append_only_data_version(
         &self,
         name: XorName,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -72,7 +72,7 @@ pub fn run() -> Result<(), String> {
     debug!("Processing command: {:?}", args);
 
     match args.cmd {
-        SubCommands::Auth { cmd } => auth_commander(cmd, &mut safe),
+        SubCommands::Auth { cmd, port } => auth_commander(cmd, port, &mut safe),
         SubCommands::Cat(cmd) => cat_commander(cmd, output_fmt, &mut safe),
         SubCommands::Keypair {} => {
             let key_pair = safe.keypair()?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,7 +40,7 @@ struct CmdArgs {
     // #[structopt(short = "q", long = "query", raw(global = "true"))]
     query: Option<String>,
     /// Dry run of command. No data will be written. No coins spent.
-    // #[structopt(long = "dry-run", raw(global = "true"))]
+    #[structopt(short = "n", long = "dry-run", raw(global = "true"))]
     dry: bool,
     /// Base encoding to be used for XOR-URLs generated. Currently supported: base32z (default), base32 and base64
     #[structopt(long = "xorurl", raw(global = "true"))]
@@ -90,7 +90,7 @@ pub fn run() -> Result<(), String> {
             match args.cmd {
                 SubCommands::Keys { cmd } => key_commander(cmd, output_fmt, &mut safe),
                 SubCommands::Wallet { cmd } => wallet_commander(cmd, output_fmt, &mut safe),
-                SubCommands::Files { cmd } => files_commander(cmd, output_fmt, &mut safe),
+                SubCommands::Files { cmd } => files_commander(cmd, output_fmt, args.dry, &mut safe),
                 _ => Err("Command not supported yet".to_string()),
             }
         }

--- a/src/subcommands/auth.rs
+++ b/src/subcommands/auth.rs
@@ -27,7 +27,11 @@ pub enum AuthSubCommands {
     Clear {},
 }
 
-pub fn auth_commander(cmd: Option<AuthSubCommands>, safe: &mut Safe) -> Result<(), String> {
+pub fn auth_commander(
+    cmd: Option<AuthSubCommands>,
+    port: Option<u16>,
+    safe: &mut Safe,
+) -> Result<(), String> {
     let file_path = credentials_file_path()?;
     let mut file = File::create(&file_path)
         .map_err(|_| format!("Unable to create credentials file at {}", file_path))?;
@@ -45,7 +49,7 @@ pub fn auth_commander(cmd: Option<AuthSubCommands>, safe: &mut Safe) -> Result<(
             println!("Authorising CLI application...");
 
             let auth_credentials = safe
-                .auth_app(APP_ID, APP_NAME, APP_VENDOR)
+                .auth_app(APP_ID, APP_NAME, APP_VENDOR, port)
                 .map_err(|err| format!("Application authorisation failed: {}", err))?;
 
             file.write_all(auth_credentials.as_bytes())

--- a/src/subcommands/container.rs
+++ b/src/subcommands/container.rs
@@ -23,7 +23,7 @@ pub enum ContainerSubCommands {
         #[structopt(short = "p", long = "publish")]
         publish: bool,
         /// Do not require new versions for container edits
-        #[structopt(short = "n", long = "non_versioned")]
+        #[structopt(short = "e", long = "non_versioned")]
         non_versioned: bool,
     },
     #[structopt(name = "add")]

--- a/src/subcommands/fake_auth.rs
+++ b/src/subcommands/fake_auth.rs
@@ -19,7 +19,11 @@ pub enum AuthSubCommands {
     Clear {},
 }
 
-pub fn auth_commander(cmd: Option<AuthSubCommands>, _safe: &mut Safe) -> Result<(), String> {
+pub fn auth_commander(
+    cmd: Option<AuthSubCommands>,
+    _port: Option<u16>,
+    _safe: &mut Safe,
+) -> Result<(), String> {
     match cmd {
         Some(AuthSubCommands::Clear {}) => {
             debug!("Fake-auth is enabled so we don't try to clear the credentials file");

--- a/src/subcommands/files.rs
+++ b/src/subcommands/files.rs
@@ -57,6 +57,7 @@ pub enum FilesSubCommands {
 pub fn files_commander(
     cmd: Option<FilesSubCommands>,
     output_fmt: OutputFmt,
+    dry_run: bool,
     safe: &mut Safe,
 ) -> Result<(), String> {
     match cmd {
@@ -67,7 +68,7 @@ pub fn files_commander(
         }) => {
             // create FilesContainer from a given path to local files/folders
             let (files_container_xorurl, processed_files, _files_map) =
-                safe.files_container_create(&location, dest, recursive)?;
+                safe.files_container_create(&location, dest, recursive, dry_run)?;
 
             // Now let's just print out the content of the FilesMap
             if OutputFmt::Pretty == output_fmt {
@@ -102,7 +103,7 @@ pub fn files_commander(
 
             // Update the FilesContainer on the Network
             let (version, processed_files, _files_map) =
-                safe.files_container_sync(&location, &target, recursive, delete)?;
+                safe.files_container_sync(&location, &target, recursive, delete, dry_run)?;
 
             // Now let's just print out the content of the FilesMap
             if OutputFmt::Pretty == output_fmt {

--- a/src/subcommands/files.rs
+++ b/src/subcommands/files.rs
@@ -48,7 +48,7 @@ pub enum FilesSubCommands {
         /// Recursively sync folders and files found in the source location
         #[structopt(short = "r", long = "recursive")]
         recursive: bool,
-        /// Delete files found at the target FilesContainer that are not in the source location
+        /// Delete files found at the target FilesContainer that are not in the source location. This is only allowed when --recursive is passed as well.
         #[structopt(short = "d", long = "delete")]
         delete: bool,
     },

--- a/src/subcommands/mod.rs
+++ b/src/subcommands/mod.rs
@@ -40,6 +40,9 @@ pub enum SubCommands {
         /// subcommands
         #[structopt(subcommand)]
         cmd: Option<AuthSubCommands>,
+        #[structopt(long = "port")]
+        /// Port number where to send the authorisaton request to. If not provided, default port 41805 is assumed.
+        port: Option<u16>,
     },
     #[structopt(name = "container")]
     /// Create a new SAFE Network account with the credentials provided


### PR DESCRIPTION
Resolves #157 

This PR also:
- Implements an additional feature to allow the user to set the port number where the authorisation request shall be sent to with `$ safe auth --port <port number>` command.
- Implements the `--dry-run` feature for the `files put` and `files sync` commands
- Runs the safe_auth service in at a random port each time for tests