### PR TITLE
Use Project Specific Slave

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ properties([
 
 stage('build & test') {
     parallel linux: {
-        node('docker') {
+        node('safe_cli') {
             checkout(scm)
             runTests(false)
             packageBuildArtifacts('linux')
@@ -33,7 +33,7 @@ stage('build & test') {
 }
 
 stage('deploy') {
-    node('docker') {
+    node('safe_cli') {
         if (env.BRANCH_NAME == "master") {
             checkout(scm)
             sh("git fetch --tags --force")


### PR DESCRIPTION
Changes the build to use the project specific slave rather than the generic slave.

This slave has the updated container on it.
