### PR TITLE
feat(xorurl): use one byte to encode SAFE native data type, and another two bytes for the content type info

### DIFF
--- a/resources/test-scripts/all-tests
+++ b/resources/test-scripts/all-tests
@@ -25,14 +25,14 @@ function setup_safe_auth() {
 
 set -e -x
 
-# first setup auth CLI
-setup_safe_auth
-
-# lint
+# let's first run lint...
 cargo clippy --all-targets --all-features -- -D warnings
 
-# check formatting
+# ...and let's check formatting before doing anything else
 cargo fmt -- --check
+
+# setup auth CLI service
+setup_safe_auth
 
 # run tests with CLI's own mock
 cargo test --release --features=scl-mock -- --test-threads=1

--- a/src/api/fetch.rs
+++ b/src/api/fetch.rs
@@ -9,7 +9,8 @@
 use super::files::FilesMap;
 use super::helpers::get_host_and_path;
 use super::nrs::{xorname_from_nrs_string, NRS_MAP_TYPE_TAG};
-use super::xorurl::{SafeContentType, SafeDataType};
+use super::xorurl::SafeContentType;
+pub use super::xorurl::SafeDataType;
 
 use super::{Error, ResultReturn, Safe, XorName, XorUrlEncoder};
 use log::{debug, info};

--- a/src/api/fetch.rs
+++ b/src/api/fetch.rs
@@ -238,7 +238,7 @@ fn test_fetch_wallet() {
         content
             == SafeData::Wallet {
                 xorname: xorurl_encoder.xorname(),
-                type_tag: 10_000,
+                type_tag: 1_000,
                 data_type: SafeDataType::SeqMutableData,
             }
     );
@@ -261,7 +261,7 @@ fn test_fetch_files_container() {
         content
             == SafeData::FilesContainer {
                 xorname: xorurl_encoder.xorname(),
-                type_tag: 10_100,
+                type_tag: 1_100,
                 version: 1,
                 files_map,
                 data_type: SafeDataType::PublishedSeqAppendOnlyData,
@@ -309,7 +309,7 @@ fn test_fetch_resolvable_container() {
             ..
         } => {
             assert_eq!(xorname, xorurl_encoder.xorname());
-            assert_eq!(type_tag, 10_100);
+            assert_eq!(type_tag, 1_100);
             assert_eq!(version, 1);
             assert_eq!(data_type, SafeDataType::PublishedSeqAppendOnlyData);
             assert_eq!(files_map, the_files_map);

--- a/src/api/files.rs
+++ b/src/api/files.rs
@@ -30,7 +30,7 @@ pub type FilesMap = BTreeMap<String, FileItem>;
 type ProcessedFiles = BTreeMap<String, (String, String)>;
 
 // Type tag to use for the FilesContainer stored on AppendOnlyData
-const FILES_CONTAINER_TYPE_TAG: u64 = 10_100;
+const FILES_CONTAINER_TYPE_TAG: u64 = 1_100;
 
 const ERROR_MSG_NO_FILES_CONTAINER_FOUND: &str = "No FilesContainer found at this address";
 

--- a/src/api/keys.rs
+++ b/src/api/keys.rs
@@ -9,7 +9,7 @@
 use super::helpers::{
     parse_coins_amount, pk_from_hex, pk_to_hex, sk_from_hex, xorname_from_pk, KeyPair,
 };
-use super::xorurl::SafeContentType;
+use super::xorurl::{SafeContentType, SafeDataType};
 use super::{Error, ResultReturn, Safe, XorUrl, XorUrlEncoder};
 use threshold_crypto::SecretKey;
 use unwrap::unwrap;
@@ -117,7 +117,8 @@ impl Safe {
         let xorurl = XorUrlEncoder::encode(
             xorname,
             0,
-            SafeContentType::CoinBalance,
+            SafeDataType::CoinBalance,
+            SafeContentType::Raw,
             None,
             &self.xorurl_base,
         )?;
@@ -152,7 +153,8 @@ impl Safe {
         let xorurl = XorUrlEncoder::encode(
             xorname,
             0,
-            SafeContentType::CoinBalance,
+            SafeDataType::CoinBalance,
+            SafeContentType::Raw,
             None,
             &self.xorurl_base,
         )?;
@@ -369,8 +371,8 @@ fn test_keys_test_coins_balance_wrong_location() {
         unwrap!(safe.keys_balance_from_xorurl(&xorurl, &unwrap!(key_pair.clone()).sk));
     assert_eq!(amount, current_balance);
 
-    // let's corrupt the XOR-URL
-    xorurl.replace_range(11..16, "ccccc");
+    // let's corrupt the XOR-URL right where the encoded xorname bytes are in the string
+    xorurl.replace_range(13..18, "ccccc");
     let current_balance = safe.keys_balance_from_xorurl(&xorurl, &unwrap!(key_pair).sk);
     match current_balance {
         Err(Error::InvalidInput(msg)) => assert!(msg.contains(

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -22,7 +22,7 @@ mod wallet;
 mod xorurl;
 
 pub use errors::{Error, ResultReturn};
-pub use fetch::SafeData;
+pub use fetch::{SafeData, SafeDataType};
 pub use keys::BlsKeyPair;
 pub use safe_nd::{XorName, XOR_NAME_LEN};
 pub use xorurl::{XorUrl, XorUrlEncoder};

--- a/src/api/wallet.rs
+++ b/src/api/wallet.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::helpers::{parse_coins_amount, sk_from_hex, xorname_from_pk, KeyPair};
-use super::xorurl::SafeContentType;
+use super::xorurl::{SafeContentType, SafeDataType};
 use super::{Error, ResultReturn};
 use super::{Safe, XorUrl, XorUrlEncoder};
 use log::debug;
@@ -39,6 +39,7 @@ impl Safe {
         XorUrlEncoder::encode(
             xorname,
             WALLET_TYPE_TAG,
+            SafeDataType::SeqMutableData,
             SafeContentType::Wallet,
             None,
             &self.xorurl_base,
@@ -58,7 +59,8 @@ impl Safe {
         let xorurl = XorUrlEncoder::encode(
             xorname,
             0,
-            SafeContentType::CoinBalance,
+            SafeDataType::CoinBalance,
+            SafeContentType::Raw,
             None,
             &self.xorurl_base,
         )?;

--- a/src/api/wallet.rs
+++ b/src/api/wallet.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 use unwrap::unwrap; // TODO: remove all unwraps from this file
 
 // Type tag used for the Wallet container
-const WALLET_TYPE_TAG: u64 = 10_000;
+const WALLET_TYPE_TAG: u64 = 1_000;
 
 const WALLET_DEFAULT: &str = "_default";
 const WALLET_DEFAULT_BYTES: &[u8] = b"_default";

--- a/src/subcommands/cat.rs
+++ b/src/subcommands/cat.rs
@@ -46,12 +46,12 @@ pub fn cat_commander(
             files_map,
             type_tag,
             xorname,
-            native_type,
+            data_type,
         } => {
             // Render FilesContainer
             if OutputFmt::Pretty == output_fmt {
                 if cmd.info {
-                    println!("Native data type: {}", native_type);
+                    println!("Native data type: {}", data_type);
                     println!("Type tag: {}", type_tag,);
                     println!("XOR name: 0x{}", xorname_to_hex(&xorname));
                     println!();
@@ -77,9 +77,9 @@ pub fn cat_commander(
                 table.printstd();
             } else if cmd.info {
                 println!(
-                        "[{}, {{ \"native_type\": \"{}\", \"type_tag\": \"{}\", \"xorname\": \"{}\" }}, {:?}]",
+                        "[{}, {{ \"data_type\": \"{}\", \"type_tag\": \"{}\", \"xorname\": \"{}\" }}, {:?}]",
                         xorurl,
-                        native_type,
+                        data_type,
                         type_tag,
                         xorname_to_hex(&xorname),
                         files_map
@@ -88,7 +88,7 @@ pub fn cat_commander(
                 println!("[{}, {:?}]", xorurl, files_map);
             }
         }
-        SafeData::ImmutableData { data, xorname } => {
+        SafeData::PublishedImmutableData { data, xorname } => {
             if cmd.info {
                 println!("Native data type: ImmutableData (published)");
                 println!("XOR name: 0x{}", xorname_to_hex(&xorname));


### PR DESCRIPTION
Resolves #150 