### PR TITLE
Run Clippy in Parallel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,6 +29,12 @@ stage('build & test') {
             packageBuildArtifacts('macos')
             uploadBuildArtifacts()
         }
+    },
+    clippy: {
+        node('safe_cli') {
+            checkout(scm)
+            sh("make clippy")
+        }
     }
 }
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,16 @@ build-container:
 push-container:
 	docker push maidsafe/safe-cli-build:${SAFE_CLI_VERSION}
 
+clippy:
+ifeq ($(UNAME_S),Linux)
+	docker run --name "safe-cli-build-${UUID}" -v "${PWD}":/usr/src/safe-cli:Z \
+		-u ${USER_ID}:${GROUP_ID} \
+		maidsafe/safe-cli-build:${SAFE_CLI_VERSION} \
+		/bin/bash -c "cargo clippy --all-targets --all-features -- -D warnings"
+else
+	cargo clippy --all-targets --all-features -- -D warnings
+endif
+
 test:
 ifndef SAFE_AUTH_PORT
 	$(eval SAFE_AUTH_PORT := ${SAFE_AUTH_DEFAULT_PORT})

--- a/resources/test-scripts/all-tests
+++ b/resources/test-scripts/all-tests
@@ -28,9 +28,6 @@ set -e -x
 # first setup auth CLI
 setup_safe_auth
 
-# lint
-cargo clippy --all-targets --all-features -- -D warnings
-
 # check formatting
 cargo fmt -- --check
 


### PR DESCRIPTION
Runs clippy in parallel only on Linux.

So it turns out this doesn't save a huge amount of time, but it seems to stop the Windows machine running out of memory, so I think we should just keep it this way.

It's mainly the Windows build that's really slow and also compiling safe auth is adding in a lot of time, but we can deal with that at another time.