### PR TITLE
 feat(cat): implement an additional level for --info to cat command, plus additional validations to files and nrs commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ In this section we will explore the CLI commands which allow users to generate, 
 
 #### NRS Create
 
-Creating a friendly name on the Network can be achieved with the `nrs create` subcommand. This subcommand generates an NRS Container automatically linking it to any data we decide to link the friendly name to. An NRS Container is stored on the Network as a `Published AppendOnlyData` data, and contains an NRS Map using RDF for its data representation (since this is still under development, pseudo-RDF data is now being used temporarily). This Map has a list of subnames and where each of them are being linked to, e.g. `mysubname` can be created as a subname of `mywebsite` NRS name by having `mysubname` linked to a particular `FilesContainer` XOR-URL so that it can be fetched with `safe://mysubname.mywebsite`.
+Creating a friendly name on the Network can be achieved with the `nrs create` subcommand. This subcommand generates an NRS Container automatically linking it to any data we decide to link the friendly name to. An NRS Container is stored on the Network as a `Published AppendOnlyData` data, and it contains an NRS Map using RDF for its data representation (since this is still under development, pseudo-RDF data is now being used temporarily). This Map has a list of subnames and where each of them are being linked to, e.g. `mysubname` can be created as a subname of `mywebsite` NRS name by having `mysubname` linked to a particular `FilesContainer` XOR-URL so that it can be fetched with `safe://mysubname.mywebsite`.
 
 Let's imagine we have uploaded the files and folders of a website we want to publish on the SAFE Network with `files put` command:
 ```shell
@@ -521,10 +521,12 @@ FilesContainer created at: "safe://hnyynyie8kccparz3pcxj9uisdc4gyzcpem9dfhehhjd6
 
 As we know that website is now publicly available on the SAFE Network for anyone who wants to visit using its XOR-URL "safe://hnyynyie8kccparz3pcxj9uisdc4gyzcpem9dfhehhjd6hpzwf8se5w1zobnc" with either `$ safe cat` command, or a SAFE Browser. But let's now create a NRS name for it and obtain its human friendly NRS-URL:
 ```shell
-$ safe nrs create mywebsite --link safe://hnyynyie8kccparz3pcxj9uisdc4gyzcpem9dfhehhjd6hpzwf8se5w1zobnc
+$ safe nrs create mywebsite --link safe://hnyynyie8kccparz3pcxj9uisdc4gyzcpem9dfhehhjd6hpzwf8se5w1zobnc?v=0
 New NRS Map for "safe://mywebsite" created at: "safe://hnyydyz7utb6npt9kg3aksgorfwmkphet8u8z3or4nsu8n3bj8yiep4a91bqh"
-+  mywebsite  safe://hnyynyie8kccparz3pcxj9uisdc4gyzcpem9dfhehhjd6hpzwf8se5w1zobnc
++  mywebsite  safe://hnyynyie8kccparz3pcxj9uisdc4gyzcpem9dfhehhjd6hpzwf8se5w1zobnc?v=0
 ```
+
+Note that we provided a versioned URL to the `--link` argument in the command above, i.e. a URL which targets a specific version of the content with `?v=<version number>`. Any type of content which can have different versions (like the case of a `FilesContainer` in our example) can be mapped/linked from an NRS name/subname only if a specific version is provided in the link URL.
 
 We can now share the NRS-URL `safe://mywebsite` to anyone who wants to visit our website. Using this NRS-URL we can now fetch the same content we would do when using the `FilesContainer` XOR-URL we linked to it, thus we can fetch it using the following command:
 ```shell
@@ -565,9 +567,9 @@ For example, you may wish to have `safe://mywebsite` to be about you in general,
 
 To create a public name with subnames, you need only to pass the full string with `.` separators, just like any traditional URL, to the CLI:
 ```shell
-$ safe nrs create blog.mywebsite --link safe://hnyynyie8kccparz3pcxj9uisdc4gyzcpem9dfhehhjd6hpzwf8se5w1zobnc
+$ safe nrs create blog.mywebsite --link safe://hnyynyie8kccparz3pcxj9uisdc4gyzcpem9dfhehhjd6hpzwf8se5w1zobnc?v=0
 New NRS Map for "safe://blog.mywebsite" created at: "safe://hnyydyz7utb6npt9kg3aksgorfwmkphet8u8z3or4nsu8n3bj8yiep4a91bqh"
-+  blog.mywebsite  safe://hnyynyie8kccparz3pcxj9uisdc4gyzcpem9dfhehhjd6hpzwf8se5w1zobnc
++  blog.mywebsite  safe://hnyynyie8kccparz3pcxj9uisdc4gyzcpem9dfhehhjd6hpzwf8se5w1zobnc?v=0
 ```
 
 As the NRS CLI advances, you'll be able to individually add to both `blog.mywebsite`, or indeed just `mywebsite`, as well as change what the `default` resource to retrieve is for both.
@@ -578,7 +580,7 @@ Once a public name has been created with `nrs create` command, more sub names ca
 
 Let's add `profile` sub name to the `mywebsite` NRS name we created before:
 ```shell
-$ safe nrs add profile.mywebsite --link safe://hnyynyipybem7ihnzqya3w31seezj4i6u8ckg9d7s39exz37z3nxue3cnkbnc
+$ safe nrs add profile.mywebsite --link safe://hnyynyipybem7ihnzqya3w31seezj4i6u8ckg9d7s39exz37z3nxue3cnkbnc?v=0
 NRS Map updated (version 1): "safe://hnyydyz7utb6npt9kg3aksgorfwmkphet8u8z3or4nsu8n3bj8yiep4a91bqh"
 +  profile.mywebsite  safe://hnyynyz8m4pkok41qrn9gkrwz35fu8zxfkwrc9xrt595wjtodacx9n8u3wbnc
 ```
@@ -586,9 +588,9 @@ NRS Map updated (version 1): "safe://hnyydyz7utb6npt9kg3aksgorfwmkphet8u8z3or4ns
 The safe nrs add command can also be used to update subnames after they have been added to a public name.
 For example, if we have made changes to files mapped to the `profile.mywebsite` NRS subname we created before, we can use `nrs add` to update its link:
 ```shell
-$ safe nrs add profile.mywebsite --link safe://hnyynyw9ru4afkbfee5m4ca4jbho4f5bj6ynep5k1pioyge6dihfqyjfrnbnc
+$ safe nrs add profile.mywebsite --link safe://hnyynyw9ru4afkbfee5m4ca4jbho4f5bj6ynep5k1pioyge6dihfqyjfrnbnc?v=0
 NRS Map updated (version 2): "safe://profile.hnyydyz7utb6npt9kg3aksgorfwmkphet8u8z3or4nsu8n3bj8yiep4a91bqh"
-+  profile.mywebsite  safe://hnyynyw9ru4afkbfee5m4ca4jbho4f5bj6ynep5k1pioyge6dihfqyjfrnbnc
++  profile.mywebsite  safe://hnyynyw9ru4afkbfee5m4ca4jbho4f5bj6ynep5k1pioyge6dihfqyjfrnbnc?v=0
 ```
 
 #### NRS Remove
@@ -599,7 +601,7 @@ Let's remove the `profile` sub name from the `mywebsite` NRS name we added befor
 ```shell
 $ safe nrs remove profile.mywebsite
 NRS Map updated (version 3): "safe://hnyydyz7utb6npt9kg3aksgorfwmkphet8u8z3or4nsu8n3bj8yiep4a91bqh"
--  profile.mywebsite  safe://hnyynyw9ru4afkbfee5m4ca4jbho4f5bj6ynep5k1pioyge6dihfqyjfrnbnc
+-  profile.mywebsite  safe://hnyynyw9ru4afkbfee5m4ca4jbho4f5bj6ynep5k1pioyge6dihfqyjfrnbnc?v=0
 ```
 
 ### SAFE-URLs
@@ -611,6 +613,41 @@ All these types of safe:// URLs can be used in any of the supported CLI commands
 E.g. we can retrieve the content of a website with the `cat` command using either its XOR-URL or its NRS-URL, and either fetching the latest version of it or supplying the query param to get a specific version of it. Thus, if we wanted to fetch `version #1` of the site we published at `safe://mywebsite` (which NRS Map Container XOR-URL is `safe://hnyydyz7utb6npt9kg3aksgorfwmkphet8u8z3or4nsu8n3bj8yiep4a91bqh`), the following two commands would be equivalent:
 - `$ safe cat safe://hnyydyz7utb6npt9kg3aksgorfwmkphet8u8z3or4nsu8n3bj8yiep4a91bqh?v=1`
 - `$ safe cat safe://mywebsite?v=1`
+
+In both cases the NRS Map Container will be found (from above URLs) by decoding the XOR-URL or by resolving NRS public name. Once that's done, and since the content is an NRS Map, following the rules defined by NRS and the map found in it the target link will be resolved from it. In some circumstances, it may be useful to get information about the resolution of a URL, which can be obtained using the `cat` command.
+
+We've seen before that we can provide `--info` flag to the `cat` command to obtain more information about the content being retrieved, but it's also possible to request a higher level of information by passing `-ii` or `-iii` (which are equivalent to pass `--info` twice or thrice respectively) to the `cat` command:
+```shell
+$ safe cat safe://mywebsite/contact/form.html -iii
+Native data type: ImmutableData (published)
+XOR name: 0x8fa90a8234747a9672d22d030984b94f1cd640136e8b659e23249a664eb70e71
+
+Resolved using NRS Map:
+PublicName: "mywebsite"
+Container XOR-URL: safe://hnyydyz7utb6npt9kg3aksgorfwmkphet8u8z3or4nsu8n3bj8yiep4a91bqh
+Native data type: PublishedSeqAppendOnlyData
+Type tag: 1500
+XOR name: 0xfb3887c26c7ea3670ab1a042d16a6f1113ccf7cc09a15a6716429382a86eb1f9
+Version: 3
++------------------+----------------------+----------------------+--------------------------------------------------------------------------+
+| NRS name/subname | Created              | Modified             | Link                                                                     |
++------------------+----------------------+----------------------+--------------------------------------------------------------------------+
+| mywebsite        | 2019-07-24T14:32:13Z | 2019-07-24T14:32:13Z | safe://hnyynyie8kccparz3pcxj9uisdc4gyzcpem9dfhehhjd6hpzwf8se5w1zobnc?v=0 |
++------------------+----------------------+----------------------+--------------------------------------------------------------------------+
+| blog.mywebsite   | 2019-07-24T16:52:30Z | 2019-07-24T16:52:30Z | safe://hnyynyie8kccparz3pcxj9uisdc4gyzcpem9dfhehhjd6hpzwf8se5w1zobnc?v=0 |
++------------------+----------------------+----------------------+--------------------------------------------------------------------------+
+
+Raw content of the file:
+<!DOCTYPE html>
+<html>
+<body>
+<h2>Contact Form</h2>
+<form>
+  ...
+</form>
+</body>
+</html>
+```
 
 ### Update
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Various global flags are available (those commented out are not yet implemented)
 # --root                   The account's Root Container address
 -V, --version              Prints version information
 # -v, --verbose            Increase output verbosity. (More logs!)
--o, --output <output_fmt>  Output data serlialisation. Currently only supported 'json'
+-o, --output <output_fmt>  Output data serialisation. Currently only supported 'json'
 # -q, --query <query>      Enable to query the output via SPARQL eg.
 --xorurl <xorurl_base>     Base encoding to be used for XOR-URLs generated. Currently supported: base32z
                            (default), base32 and base64
@@ -226,7 +226,7 @@ OPTIONS:
                                   automatically generated and inserted. The corresponding secret key will be prompted if
                                   not provided with '--sk'
         --name <name>             The name to give the spendable balance
-    -o, --output <output_fmt>     Output data serlialisation. Currently only supported 'json'
+    -o, --output <output_fmt>     Output data serialisation. Currently only supported 'json'
     -w, --pay-with <pay_with>     The secret key of a Key for paying the operation costs
         --preload <preload>       Preload the key with a balance
         --sk <secret>             Pass the secret key needed to make the balance spendable, it will be prompted if not
@@ -279,7 +279,7 @@ OPTIONS:
         --keyurl <keyurl>         The Key's safe://xor-url to verify it matches/corresponds to the secret key provided.
                                   The corresponding secret key will be prompted if not provided with '--sk'
         --name <name>             The name to give this spendable balance
-    -o, --output <output_fmt>     Output data serlialisation. Currently only supported 'json'
+    -o, --output <output_fmt>     Output data serialisation. Currently only supported 'json'
     -w, --pay-with <pay_with>     The secret key of a Key for paying the operation costs. If not provided, the default
                                   wallet from the account will be used
         --sk <secret>             Pass the secret key needed to make the balance spendable, it will be prompted if not

--- a/src/api/fake_scl.rs
+++ b/src/api/fake_scl.rs
@@ -6,8 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use super::helpers::create_random_xorname;
 use super::safe_net::AppendOnlyDataRawData;
-use super::xorurl::create_random_xorname;
 use super::{Error, ResultReturn, SafeApp};
 use crate::api::helpers::{
     parse_coins_amount, parse_hex, vec_to_hex, xorname_from_pk, xorname_to_hex,

--- a/src/api/fetch.rs
+++ b/src/api/fetch.rs
@@ -85,7 +85,7 @@ impl Safe {
     /// assert!(data_string.starts_with("hello tests!"));
     /// ```
     pub fn fetch(&self, url: &str) -> ResultReturn<SafeData> {
-        let the_xor = Safe::parse_url(url)?;
+        let mut the_xor = Safe::parse_url(url)?;
         let xorurl = the_xor.to_string()?;
         info!("URL parsed successfully, fetching: {}", xorurl);
         debug!("Fetching content of type: {:?}", the_xor.content_type());
@@ -189,9 +189,10 @@ impl Safe {
 
                 let (_, public_name, _, _) = get_subnames_host_path_and_version(url)?;
                 let content = self.fetch(&url_with_path)?;
+                the_xor.set_path(""); // we don't want the path, just the NRS Map xorurl and version
                 let nrs_map_container = NrsMapContainerInfo {
                     public_name,
-                    xorurl,
+                    xorurl: the_xor.to_string()?,
                     xorname: the_xor.xorname(),
                     type_tag: the_xor.type_tag(),
                     version,

--- a/src/api/fetch.rs
+++ b/src/api/fetch.rs
@@ -13,8 +13,9 @@ pub use super::xorurl::SafeContentType;
 pub use super::xorurl::{SafeDataType, XorUrlEncoder};
 use super::{Error, ResultReturn, Safe, XorName};
 use log::{debug, info};
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 pub struct NrsMapContainerInfo {
     pub public_name: String,
     pub xorurl: String,
@@ -25,7 +26,7 @@ pub struct NrsMapContainerInfo {
     pub data_type: SafeDataType,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 pub enum SafeData {
     Key {
         xorname: XorName,
@@ -63,7 +64,7 @@ impl Safe {
     /// # use safe_cli::{Safe, SafeData};
     /// # use unwrap::unwrap;
     /// # use std::collections::BTreeMap;
-    /// # let mut safe = Safe::new("base32z".to_string());
+    /// # let mut safe = Safe::new("base32z");
     /// # unwrap!(safe.connect("", Some("fake-credentials")));
     /// let (xorurl, _, _) = unwrap!(safe.files_container_create("tests/testfolder/", None, true, false));
     ///
@@ -257,7 +258,7 @@ fn embed_resolved_from(
 fn test_fetch_key() {
     use super::xorurl::XorUrlEncoder;
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let preload_amount = "1324.12";
     let (xorurl, _key_pair) = unwrap!(safe.keys_create_preload_test_coins(preload_amount, None));
@@ -277,7 +278,7 @@ fn test_fetch_key() {
 fn test_fetch_wallet() {
     use super::xorurl::XorUrlEncoder;
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let xorurl = unwrap!(safe.wallet_create());
 
@@ -298,7 +299,7 @@ fn test_fetch_wallet() {
 fn test_fetch_files_container() {
     use super::xorurl::XorUrlEncoder;
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     safe.connect("", Some("")).unwrap();
 
@@ -343,7 +344,7 @@ fn test_fetch_resolvable_container() {
 
     let site_name: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
 
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     safe.connect("", Some("")).unwrap();
 
     let (xorurl, _, the_files_map) =
@@ -390,7 +391,7 @@ fn test_fetch_resolvable_map_data() {
 
     let site_name: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
 
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     safe.connect("", Some("")).unwrap();
 
     let (xorurl, _, _the_files_map) =
@@ -432,7 +433,7 @@ fn test_fetch_resolvable_map_data() {
 fn test_fetch_published_immutable_data() {
     use super::xorurl::XorUrlEncoder;
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let data = b"Something super immutable";
     let xorurl = safe.files_put_published_immutable(data).unwrap();
@@ -454,7 +455,7 @@ fn test_fetch_unsupported() {
     use super::helpers::create_random_xorname;
     use super::xorurl::XorUrlEncoder;
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let xorname = create_random_xorname();
     let type_tag = 575_756_443;

--- a/src/api/fetch.rs
+++ b/src/api/fetch.rs
@@ -344,10 +344,15 @@ fn test_fetch_resolvable_container() {
     let (xorurl, _, the_files_map) =
         unwrap!(safe.files_container_create("tests/testfolder", None, true, false));
 
-    let xorurl_encoder = unwrap!(XorUrlEncoder::from_url(&xorurl));
-
-    let (_nrs_map_xorurl, _, _nrs_map) =
-        unwrap!(safe.nrs_map_container_create(&site_name, &xorurl, true, true, false));
+    let mut xorurl_encoder = unwrap!(XorUrlEncoder::from_url(&xorurl));
+    xorurl_encoder.set_content_version(Some(0));
+    let (_nrs_map_xorurl, _, _nrs_map) = unwrap!(safe.nrs_map_container_create(
+        &site_name,
+        &unwrap!(xorurl_encoder.to_string("")),
+        true,
+        true,
+        false
+    ));
 
     let content = unwrap!(safe.fetch(&format!("safe://{}", site_name)));
 
@@ -386,8 +391,15 @@ fn test_fetch_resolvable_map_data() {
     let (xorurl, _, _the_files_map) =
         unwrap!(safe.files_container_create("tests/testfolder", None, true, false));
 
-    let (nrs_map_xorurl, _, the_nrs_map) =
-        unwrap!(safe.nrs_map_container_create(&site_name, &xorurl, true, true, false));
+    let mut xorurl_encoder = unwrap!(XorUrlEncoder::from_url(&xorurl));
+    xorurl_encoder.set_content_version(Some(0));
+    let (nrs_map_xorurl, _, the_nrs_map) = unwrap!(safe.nrs_map_container_create(
+        &site_name,
+        &unwrap!(xorurl_encoder.to_string("")),
+        true,
+        true,
+        false
+    ));
 
     let xorurl_encoder = unwrap!(XorUrlEncoder::from_url(&nrs_map_xorurl));
     let content = unwrap!(safe.fetch(&format!("safe://{}", site_name)));
@@ -434,7 +446,7 @@ fn test_fetch_published_immutable_data() {
 
 #[test]
 fn test_fetch_unsupported() {
-    use super::xorurl::create_random_xorname;
+    use super::helpers::create_random_xorname;
     use super::xorurl::XorUrlEncoder;
     use unwrap::unwrap;
     let mut safe = Safe::new("base32z".to_string());

--- a/src/api/files.rs
+++ b/src/api/files.rs
@@ -1239,7 +1239,7 @@ fn test_files_container_sync_update_nrs_unversioned_link() {
         Err(err) => assert_eq!(
             err,
             Error::InvalidInput(format!(
-                "The link is unversioned, but the linked content (FilesContainer) is versionable. NRS resolver doesn\'t allow unversioned links for this type of content: \"{}\"",
+                "The linked content (FilesContainer) is versionable, therefore NRS requires the link to specify a version: \"{}\"",
                 unversioned_link
             ))
         ),

--- a/src/api/files.rs
+++ b/src/api/files.rs
@@ -224,7 +224,7 @@ impl Safe {
         }
 
         let (current_version, current_files_map): (u64, FilesMap) =
-            self.files_container_get(&xorurl_encoder.to_string("")?)?;
+            self.files_container_get(&xorurl_encoder.to_string()?)?;
 
         // Let's generate the list of local files paths, without uploading any new file yet
         let processed_files = file_system_dir_walk(self, location, recursive, false)?;
@@ -274,7 +274,7 @@ impl Safe {
                 // We need to update the link in the NRS container as well,
                 // to link it to the new new_version of the FilesContainer we just generated
                 xorurl_encoder.set_content_version(Some(new_version));
-                let new_link_for_nrs = xorurl_encoder.to_string("")?;
+                let new_link_for_nrs = xorurl_encoder.to_string()?;
                 let _ = self.nrs_map_container_add(url, &new_link_for_nrs, false, true, false)?;
             }
 
@@ -1204,7 +1204,7 @@ fn test_files_container_sync_update_nrs_unversioned_link() {
     let nrsurl: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
     let mut xorurl_encoder = unwrap!(XorUrlEncoder::from_url(&xorurl));
     xorurl_encoder.set_content_version(None);
-    let unversioned_link = unwrap!(xorurl_encoder.to_string(""));
+    let unversioned_link = unwrap!(xorurl_encoder.to_string());
     match safe.nrs_map_container_create(&nrsurl, &unversioned_link, false, true, false) {
         Ok(_) => panic!("NRS create was unexpectdly successful"),
         Err(err) => assert_eq!(
@@ -1260,7 +1260,7 @@ fn test_files_container_sync_update_nrs_versioned_link() {
     xorurl_encoder.set_content_version(Some(0));
     let _ = unwrap!(safe.nrs_map_container_create(
         &nrsurl,
-        &unwrap!(xorurl_encoder.to_string("")),
+        &unwrap!(xorurl_encoder.to_string()),
         false,
         true,
         false
@@ -1279,8 +1279,8 @@ fn test_files_container_sync_update_nrs_versioned_link() {
     xorurl_encoder.set_content_version(Some(1));
     let (new_link, _) = unwrap!(safe.parse_and_resolve_url(&nrsurl));
     assert_eq!(
-        unwrap!(new_link.to_string("")),
-        unwrap!(xorurl_encoder.to_string(""))
+        unwrap!(new_link.to_string()),
+        unwrap!(xorurl_encoder.to_string())
     );
 }
 
@@ -1298,7 +1298,7 @@ fn test_files_container_sync_target_path_without_trailing_slash() {
     xorurl_encoder.set_path("path/when/sync");
     let (version, new_processed_files, new_files_map) = unwrap!(safe.files_container_sync(
         "./tests/testfolder/subfolder",
-        &unwrap!(xorurl_encoder.to_string("")),
+        &unwrap!(xorurl_encoder.to_string()),
         true,
         false,
         false,
@@ -1361,7 +1361,7 @@ fn test_files_container_sync_target_path_with_trailing_slash() {
     xorurl_encoder.set_path("/path/when/sync/");
     let (version, new_processed_files, new_files_map) = unwrap!(safe.files_container_sync(
         "./tests/testfolder/subfolder",
-        &unwrap!(xorurl_encoder.to_string("")),
+        &unwrap!(xorurl_encoder.to_string()),
         true,
         false,
         false,
@@ -1454,7 +1454,7 @@ fn test_files_container_version() {
 
     let mut xorurl_encoder = unwrap!(XorUrlEncoder::from_url(&xorurl));
     xorurl_encoder.set_content_version(None);
-    let (version, _) = unwrap!(safe.files_container_get(&unwrap!(xorurl_encoder.to_string(""))));
+    let (version, _) = unwrap!(safe.files_container_get(&unwrap!(xorurl_encoder.to_string())));
     assert_eq!(version, 1);
 }
 
@@ -1480,7 +1480,7 @@ fn test_files_container_get_with_version() {
     let mut xorurl_encoder = unwrap!(XorUrlEncoder::from_url(&xorurl));
     xorurl_encoder.set_content_version(Some(0));
     let (version, v0_files_map) =
-        unwrap!(safe.files_container_get(&unwrap!(xorurl_encoder.to_string(""))));
+        unwrap!(safe.files_container_get(&unwrap!(xorurl_encoder.to_string())));
 
     assert_eq!(version, 0);
     assert_eq!(files_map, v0_files_map);
@@ -1494,7 +1494,7 @@ fn test_files_container_get_with_version() {
     // let's fetch version 1
     xorurl_encoder.set_content_version(Some(1));
     let (version, v1_files_map) =
-        unwrap!(safe.files_container_get(&unwrap!(xorurl_encoder.to_string(""))));
+        unwrap!(safe.files_container_get(&unwrap!(xorurl_encoder.to_string())));
 
     assert_eq!(version, 1);
     assert_eq!(new_files_map, v1_files_map);
@@ -1509,7 +1509,7 @@ fn test_files_container_get_with_version() {
 
     // let's fetch version 2 (invalid)
     xorurl_encoder.set_content_version(Some(2));
-    match safe.files_container_get(&unwrap!(xorurl_encoder.to_string(""))) {
+    match safe.files_container_get(&unwrap!(xorurl_encoder.to_string())) {
         Ok(_) => panic!("unexpectdly retrieved verion 3 of container"),
         Err(Error::VersionNotFound(msg)) => assert_eq!(
             msg,

--- a/src/api/files.rs
+++ b/src/api/files.rs
@@ -45,7 +45,7 @@ impl Safe {
     ///
     /// ```rust
     /// # use safe_cli::Safe;
-    /// # let mut safe = Safe::new("base32z".to_string());
+    /// # let mut safe = Safe::new("base32z");
     /// # safe.connect("", Some("fake-credentials")).unwrap();
     /// let (xorurl, _processed_files, _files_map) = safe.files_container_create("tests/testfolder", None, true, false).unwrap();
     /// assert!(xorurl.contains("safe://"))
@@ -113,7 +113,7 @@ impl Safe {
     ///
     /// ```rust
     /// # use safe_cli::Safe;
-    /// # let mut safe = Safe::new("base32z".to_string());
+    /// # let mut safe = Safe::new("base32z");
     /// # safe.connect("", Some("fake-credentials")).unwrap();
     /// let (xorurl, _processed_files, _files_map) = safe.files_container_create("tests/testfolder", None, true, false).unwrap();
     /// let (version, files_map) = safe.files_container_get(&xorurl).unwrap();
@@ -184,7 +184,7 @@ impl Safe {
     ///
     /// ```rust
     /// # use safe_cli::Safe;
-    /// # let mut safe = Safe::new("base32z".to_string());
+    /// # let mut safe = Safe::new("base32z");
     /// # safe.connect("", Some("fake-credentials")).unwrap();
     /// let (xorurl, _processed_files, _files_map) = safe.files_container_create("tests/testfolder", None, true, false).unwrap();
     /// let (version, new_processed_files, new_files_map) = safe.files_container_sync("tests/testfolder", &xorurl, true, false, false, false).unwrap();
@@ -210,7 +210,7 @@ impl Safe {
         let xorurl_encoder = Safe::parse_url(url)?;
         if xorurl_encoder.content_version().is_some() {
             return Err(Error::InvalidInput(format!(
-                "The URL cannot cannot contain a version: {}. Use 'sync-with-version' argument if you whish to use a specific version for syncing",
+                "The target URL cannot cannot contain a version: {}",
                 url
             )));
         };
@@ -290,7 +290,7 @@ impl Safe {
     /// ## Example
     /// ```
     /// # use safe_cli::Safe;
-    /// # let mut safe = Safe::new("base32z".to_string());
+    /// # let mut safe = Safe::new("base32z");
     /// # safe.connect("", Some("fake-credentials")).unwrap();
     /// let data = b"Something super good";
     /// let xorurl = safe.files_put_published_immutable(data).unwrap();
@@ -319,7 +319,7 @@ impl Safe {
     /// ## Example
     /// ```
     /// # use safe_cli::Safe;
-    /// # let mut safe = Safe::new("base32z".to_string());
+    /// # let mut safe = Safe::new("base32z");
     /// # safe.connect("", Some("fake-credentials")).unwrap();
     /// # let data = b"Something super good";
     /// let xorurl = safe.files_put_published_immutable(data).unwrap();
@@ -737,7 +737,7 @@ fn test_files_map_create() {
 #[test]
 fn test_files_container_create_file() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let filename = "tests/testfolder/test.md";
     let (xorurl, processed_files, files_map) =
@@ -757,7 +757,7 @@ fn test_files_container_create_file() {
 #[test]
 fn test_files_container_create_dry_run() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let filename = "./tests/testfolder/";
     let (xorurl, processed_files, files_map) =
@@ -803,7 +803,7 @@ fn test_files_container_create_dry_run() {
 #[test]
 fn test_files_container_create_folder_without_trailing_slash() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let (xorurl, processed_files, files_map) =
         unwrap!(safe.files_container_create("tests/testfolder", None, true, false));
@@ -844,7 +844,7 @@ fn test_files_container_create_folder_without_trailing_slash() {
 #[test]
 fn test_files_container_create_folder_with_trailing_slash() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let (xorurl, processed_files, files_map) =
         unwrap!(safe.files_container_create("./tests/testfolder/", None, true, false));
@@ -885,7 +885,7 @@ fn test_files_container_create_folder_with_trailing_slash() {
 #[test]
 fn test_files_container_create_dest_path_without_trailing_slash() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let (xorurl, processed_files, files_map) = unwrap!(safe.files_container_create(
         "./tests/testfolder",
@@ -930,7 +930,7 @@ fn test_files_container_create_dest_path_without_trailing_slash() {
 #[test]
 fn test_files_container_create_dest_path_with_trailing_slash() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let (xorurl, processed_files, files_map) = unwrap!(safe.files_container_create(
         "./tests/testfolder",
@@ -975,7 +975,7 @@ fn test_files_container_create_dest_path_with_trailing_slash() {
 #[test]
 fn test_files_container_sync() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let (xorurl, processed_files, files_map) =
         unwrap!(safe.files_container_create("./tests/testfolder/", None, true, false));
@@ -1042,7 +1042,7 @@ fn test_files_container_sync() {
 #[test]
 fn test_files_container_sync_dry_run() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let (xorurl, processed_files, files_map) =
         unwrap!(safe.files_container_create("./tests/testfolder/", None, true, false));
@@ -1109,9 +1109,38 @@ fn test_files_container_sync_dry_run() {
 }
 
 #[test]
+fn test_files_container_sync_with_versioned_target() {
+    use unwrap::unwrap;
+    let mut safe = Safe::new("base32z");
+    unwrap!(safe.connect("", Some("fake-credentials")));
+
+    let (xorurl, _, _) =
+        unwrap!(safe.files_container_create("./tests/testfolder/", None, true, false));
+
+    let versioned_xorurl = format!("{}?v=5", xorurl);
+    match safe.files_container_sync(
+        "./tests/testfolder/subfolder/",
+        &versioned_xorurl,
+        false,
+        false,
+        true, // this flag requests the update-nrs
+        false,
+    ) {
+        Ok(_) => panic!("Sync was unexpectdly successful"),
+        Err(err) => assert_eq!(
+            err,
+            Error::InvalidInput(format!(
+                "The target URL cannot cannot contain a version: {}",
+                versioned_xorurl
+            ))
+        ),
+    };
+}
+
+#[test]
 fn test_files_container_sync_with_delete() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let (xorurl, processed_files, files_map) =
         unwrap!(safe.files_container_create("./tests/testfolder/", None, true, false));
@@ -1173,7 +1202,7 @@ fn test_files_container_sync_with_delete() {
 #[test]
 fn test_files_container_sync_delete_without_recursive() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     match safe.files_container_sync(
         "./tests/testfolder/subfolder/",
@@ -1196,7 +1225,7 @@ fn test_files_container_sync_update_nrs_unversioned_link() {
     use rand::distributions::Alphanumeric;
     use rand::{thread_rng, Rng};
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let (xorurl, _, _) =
         unwrap!(safe.files_container_create("./tests/testfolder/", None, true, false));
@@ -1220,7 +1249,7 @@ fn test_files_container_sync_update_nrs_unversioned_link() {
 #[test]
 fn test_files_container_sync_update_nrs_with_xorurl() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
 
     let (xorurl, _, _) =
@@ -1249,7 +1278,7 @@ fn test_files_container_sync_update_nrs_versioned_link() {
     use rand::distributions::Alphanumeric;
     use rand::{thread_rng, Rng};
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let (xorurl, _, _) =
         unwrap!(safe.files_container_create("./tests/testfolder/", None, true, false));
@@ -1287,7 +1316,7 @@ fn test_files_container_sync_update_nrs_versioned_link() {
 #[test]
 fn test_files_container_sync_target_path_without_trailing_slash() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let (xorurl, processed_files, files_map) =
         unwrap!(safe.files_container_create("./tests/testfolder/", None, true, false));
@@ -1349,7 +1378,7 @@ fn test_files_container_sync_target_path_without_trailing_slash() {
 #[test]
 fn test_files_container_sync_target_path_with_trailing_slash() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let (xorurl, processed_files, files_map) =
         unwrap!(safe.files_container_create("./tests/testfolder/", None, true, false));
@@ -1412,7 +1441,7 @@ fn test_files_container_sync_target_path_with_trailing_slash() {
 #[test]
 fn test_files_container_get() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let (xorurl, _processed_files, files_map) =
         unwrap!(safe.files_container_create("./tests/testfolder/", None, true, false));
@@ -1434,7 +1463,7 @@ fn test_files_container_get() {
 #[test]
 fn test_files_container_version() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let (xorurl, _, _) =
         unwrap!(safe.files_container_create("./tests/testfolder/", None, true, false));
@@ -1461,7 +1490,7 @@ fn test_files_container_version() {
 #[test]
 fn test_files_container_get_with_version() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let (xorurl, _processed_files, files_map) =
         unwrap!(safe.files_container_create("./tests/testfolder/", None, true, false));

--- a/src/api/helpers.rs
+++ b/src/api/helpers.rs
@@ -10,6 +10,8 @@ use super::{Error, ResultReturn};
 use chrono::{SecondsFormat, Utc};
 
 use log::debug;
+use rand::rngs::OsRng;
+use rand_core::RngCore;
 use safe_core::ipc::{decode_msg, resp::AuthGranted, IpcMsg, IpcResp};
 use safe_nd::{Coins, XorName, XOR_NAME_LEN};
 use std::iter::FromIterator;
@@ -73,6 +75,13 @@ pub fn xorname_from_pk(pk: &PublicKey) -> XorName {
 
 pub fn vec_to_hex(hash: Vec<u8>) -> String {
     hash.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+pub fn create_random_xorname() -> XorName {
+    let mut os_rng = OsRng::new().unwrap();
+    let mut xorname = XorName::default();
+    os_rng.fill_bytes(&mut xorname.0);
+    xorname
 }
 
 #[allow(dead_code)]

--- a/src/api/keys.rs
+++ b/src/api/keys.rs
@@ -11,6 +11,7 @@ use super::helpers::{
 };
 use super::xorurl::{SafeContentType, SafeDataType};
 use super::{Error, ResultReturn, Safe, SafeApp, XorUrl, XorUrlEncoder};
+use serde::{Deserialize, Serialize};
 use threshold_crypto::SecretKey;
 
 // A trait that the Validate derive will impl
@@ -18,7 +19,7 @@ use validator::{Validate, ValidationErrors};
 
 // We expose a BLS key pair as two hex encoded strings
 // TODO: consider supporting other encodings like base32 or just expose Vec<u8>
-#[derive(Clone, Validate)]
+#[derive(Clone, Validate, Serialize, Deserialize)]
 pub struct BlsKeyPair {
     #[validate(length(equal = "96"))]
     pub pk: String,
@@ -201,7 +202,7 @@ impl Safe {
 #[test]
 fn test_keys_create_preload_test_coins() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let (xorurl, key_pair) = unwrap!(safe.keys_create_preload_test_coins("12.23", None));
     assert!(xorurl.starts_with("safe://"));
@@ -211,7 +212,7 @@ fn test_keys_create_preload_test_coins() {
 #[test]
 fn test_keys_create_preload_test_coins_pk() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let pk = String::from("a252e6741b524ad70cf340f32d219c60a3f1a38aaec0d0dbfd24ea9ae7390e44ebdc93e7575711e65379eb0f4de083a8");
     let (xorurl, key_pair) = unwrap!(safe.keys_create_preload_test_coins("1.1", Some(pk)));
@@ -222,7 +223,7 @@ fn test_keys_create_preload_test_coins_pk() {
 #[test]
 fn test_keys_create() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let (_, from_key_pair) = unwrap!(safe.keys_create_preload_test_coins("23.23", None));
 
@@ -234,7 +235,7 @@ fn test_keys_create() {
 #[test]
 fn test_keys_create_preload() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let (_, from_key_pair) = unwrap!(safe.keys_create_preload_test_coins("543.2312", None));
 
@@ -257,7 +258,7 @@ fn test_keys_create_preload() {
 #[test]
 fn test_keys_create_preload_invalid_amounts() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     match safe.keys_create_preload_test_coins(".45", None) {
         Err(err) => assert_eq!(
@@ -308,7 +309,7 @@ fn test_keys_create_preload_invalid_amounts() {
 #[test]
 fn test_keys_create_pk() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let (_, from_key_pair) = unwrap!(safe.keys_create_preload_test_coins("1.1", None));
     let pk = pk_to_hex(&SecretKey::random().public_key());
@@ -321,7 +322,7 @@ fn test_keys_create_pk() {
 #[test]
 fn test_keys_test_coins_balance_pk() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let preload_amount = "1.154200000";
     let (_, key_pair) = unwrap!(safe.keys_create_preload_test_coins(preload_amount, None));
@@ -332,7 +333,7 @@ fn test_keys_test_coins_balance_pk() {
 #[test]
 fn test_keys_test_coins_balance_xorurl() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let preload_amount = "0.243000000";
     let (xorurl, key_pair) = unwrap!(safe.keys_create_preload_test_coins(preload_amount, None));
@@ -343,7 +344,7 @@ fn test_keys_test_coins_balance_xorurl() {
 #[test]
 fn test_keys_test_coins_balance_wrong_url() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let (_xorurl, key_pair) = unwrap!(safe.keys_create_preload_test_coins("0", None));
 
@@ -361,7 +362,7 @@ fn test_keys_test_coins_balance_wrong_url() {
 #[test]
 fn test_keys_test_coins_balance_wrong_location() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let amount = "35312.000000000";
     let (mut xorurl, key_pair) = unwrap!(safe.keys_create_preload_test_coins(amount, None));
@@ -385,7 +386,7 @@ fn test_keys_test_coins_balance_wrong_location() {
 #[test]
 fn test_keys_test_coins_balance_wrong_sk() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let (_xorurl, key_pair) = unwrap!(safe.keys_create_preload_test_coins("0", None));
     let mut unwrapped_sk = unwrap!(key_pair).sk;
@@ -403,7 +404,7 @@ fn test_keys_test_coins_balance_wrong_sk() {
 #[test]
 fn test_keys_balance_pk() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let preload_amount = "1743.234";
     let (_, from_key_pair) = unwrap!(safe.keys_create_preload_test_coins(preload_amount, None));
@@ -429,7 +430,7 @@ fn test_keys_balance_pk() {
 #[test]
 fn test_keys_balance_xorname() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let preload_amount = "435.34";
     let (from_xorname, from_key_pair) =
@@ -458,7 +459,7 @@ fn test_keys_balance_xorname() {
 #[test]
 fn test_validate_sk_for_url() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let (xorurl, key_pair) = unwrap!(safe.keys_create_preload_test_coins("23.22", None));
     let key_pair_unwrapped = unwrap!(key_pair);

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -37,7 +37,7 @@ use safe_client_libs::SafeAppScl as SafeAppImpl;
 
 pub struct Safe {
     safe_app: SafeAppImpl,
-    xorurl_base: String,
+    pub xorurl_base: String,
 }
 
 #[allow(dead_code)]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -42,10 +42,10 @@ pub struct Safe {
 
 #[allow(dead_code)]
 impl Safe {
-    pub fn new(xorurl_base: String) -> Self {
+    pub fn new(xorurl_base: &str) -> Self {
         Self {
             safe_app: SafeApp::new(),
-            xorurl_base,
+            xorurl_base: xorurl_base.to_string(),
         }
     }
 }

--- a/src/api/nrs.rs
+++ b/src/api/nrs.rs
@@ -84,7 +84,7 @@ impl Safe {
         info!("Adding to NRS map...");
         // GET current NRS map from name's TLD
         let (xorurl_encoder, _) = validate_nrs_name(name)?;
-        let xorurl = xorurl_encoder.to_string("")?;
+        let xorurl = xorurl_encoder.to_string()?;
         let (version, mut nrs_map) = self.nrs_map_container_get(&xorurl)?;
         debug!("NRS, Existing data: {:?}", nrs_map);
 
@@ -194,7 +194,7 @@ impl Safe {
         info!("Removing from NRS map...");
         // GET current NRS map from &name TLD
         let (xorurl_encoder, _) = validate_nrs_name(name)?;
-        let xorurl = xorurl_encoder.to_string("")?;
+        let xorurl = xorurl_encoder.to_string()?;
         let (version, mut nrs_map) = self.nrs_map_container_get(&xorurl)?;
         debug!("NRS, Existing data: {:?}", nrs_map);
 

--- a/src/api/nrs_map.rs
+++ b/src/api/nrs_map.rs
@@ -302,8 +302,8 @@ fn validate_nrs_link(link: &str) -> ResultReturn<()> {
         match link_encoder.content_type() {
             SafeContentType::FilesContainer | SafeContentType::NrsMapContainer => {
                 Err(Error::InvalidInput(format!(
-                    "The link is unversioned, but the linked content is versionable. NRS resolver doesn\'t allow unversioned links for this type of content: \"{}\"",
-                    link
+                    "The link is unversioned, but the linked content ({}) is versionable. NRS resolver doesn\'t allow unversioned links for this type of content: \"{}\"",
+                    link_encoder.content_type(), link
                 )))
             }
             _ => Ok(()),

--- a/src/api/nrs_map.rs
+++ b/src/api/nrs_map.rs
@@ -309,7 +309,7 @@ fn validate_nrs_link(link: &str) -> ResultReturn<()> {
         match link_encoder.content_type() {
             SafeContentType::FilesContainer | SafeContentType::NrsMapContainer => {
                 Err(Error::InvalidInput(format!(
-                    "The link is unversioned, but the linked content ({}) is versionable. NRS resolver doesn\'t allow unversioned links for this type of content: \"{}\"",
+                    "The linked content ({}) is versionable, therefore NRS requires the link to specify a version: \"{}\"",
                     link_encoder.content_type(), link
                 )))
             }

--- a/src/api/safe_client_libs.rs
+++ b/src/api/safe_client_libs.rs
@@ -613,7 +613,7 @@ fn get_secret_bls_key(safe_app: &App) -> ResultReturn<SecretKey> {
 #[test]
 fn test_put_and_get_immutable_data() {
     use super::Safe;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     safe.connect("", Some("fake-credentials")).unwrap();
 
     let id1 = b"HELLLOOOOOOO".to_vec();
@@ -630,7 +630,7 @@ fn test_put_and_get_immutable_data() {
 #[test]
 fn test_put_get_update_seq_append_only_data() {
     use super::Safe;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     safe.connect("", Some("fake-credentials")).unwrap();
 
     let key1 = b"KEY1".to_vec();
@@ -728,7 +728,7 @@ fn test_put_get_update_seq_append_only_data() {
 #[test]
 fn test_update_seq_append_only_data_error() {
     use super::Safe;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     safe.connect("", Some("fake-credentials")).unwrap();
 
     let key1 = b"KEY1".to_vec();

--- a/src/api/safe_client_libs.rs
+++ b/src/api/safe_client_libs.rs
@@ -6,9 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::helpers::xorname_from_pk;
+use super::helpers::{create_random_xorname, xorname_from_pk};
 use super::safe_net::AppendOnlyDataRawData;
-use super::xorurl::create_random_xorname;
 use super::{Error, ResultReturn, SafeApp};
 use futures::future::Future;
 use log::{debug, info, warn};

--- a/src/api/wallet.rs
+++ b/src/api/wallet.rs
@@ -236,7 +236,7 @@ impl Safe {
     /// ```
     /// # use safe_cli::Safe;
     /// # use unwrap::unwrap;
-    /// let mut safe = Safe::new("base32z".to_string());
+    /// let mut safe = Safe::new("base32z");
     /// # unwrap!(safe.connect("", Some("fake-credentials")));
     /// let wallet_xorurl = unwrap!(safe.wallet_create());
     /// let wallet_xorurl2 = unwrap!(safe.wallet_create());
@@ -349,7 +349,7 @@ impl Safe {
 #[test]
 fn test_wallet_create() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let xorurl = unwrap!(safe.wallet_create());
     assert!(xorurl.starts_with("safe://"));
@@ -361,7 +361,7 @@ fn test_wallet_create() {
 #[test]
 fn test_wallet_insert_and_balance() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let wallet_xorurl = unwrap!(safe.wallet_create());
     let (_key1_xorurl, key_pair1) = unwrap!(safe.keys_create_preload_test_coins("12.23", None));
@@ -391,7 +391,7 @@ fn test_wallet_insert_and_balance() {
 #[test]
 fn test_wallet_transfer_no_default() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let from_wallet_xorurl = unwrap!(safe.wallet_create()); // this one won't have a default balance
 
@@ -434,7 +434,7 @@ fn test_wallet_transfer_no_default() {
 #[test]
 fn test_wallet_transfer_diff_amounts() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
     let from_wallet_xorurl = unwrap!(safe.wallet_create());
     let (_key_xorurl1, key_pair1) = unwrap!(safe.keys_create_preload_test_coins("100.5", None));
@@ -489,7 +489,7 @@ fn test_wallet_transfer_diff_amounts() {
 #[test]
 fn test_wallet_transfer_to_key() {
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
 
     let from_wallet_xorurl = unwrap!(safe.wallet_create());
@@ -523,7 +523,7 @@ fn test_wallet_transfer_with_nrs_urls() {
     use rand::distributions::Alphanumeric;
     use rand::{thread_rng, Rng};
     use unwrap::unwrap;
-    let mut safe = Safe::new("base32z".to_string());
+    let mut safe = Safe::new("base32z");
     unwrap!(safe.connect("", Some("fake-credentials")));
 
     let from_wallet_xorurl = unwrap!(safe.wallet_create());

--- a/src/api/wallet.rs
+++ b/src/api/wallet.rs
@@ -301,7 +301,7 @@ impl Safe {
         // Now check if the 'to_url' is a valid Wallet or a Key URL
         let (to_xorurl_encoder, _) = self.parse_and_resolve_url(to_url)?;
         let to_xorname = if to_xorurl_encoder.content_type() == SafeContentType::Wallet {
-            let to_balance = self.wallet_get_default_balance(&to_xorurl_encoder.to_string("")?)?;
+            let to_balance = self.wallet_get_default_balance(&to_xorurl_encoder.to_string()?)?;
             XorUrlEncoder::from_url(&to_balance.xorurl)?.xorname()
         } else if to_xorurl_encoder.content_type() == SafeContentType::Raw
             && to_xorurl_encoder.data_type() == SafeDataType::CoinBalance

--- a/src/api/wallet.rs
+++ b/src/api/wallet.rs
@@ -279,21 +279,21 @@ impl Safe {
             Some(url) => {
                 // Check if 'from_url' is a valid Wallet URL
                 let (xorurl_encoder, _) = self.parse_and_resolve_url(url).map_err(|_| {
-                    Error::InvalidInput("Failed to parse the \"<from_url>\" URL".to_string())
+                    Error::InvalidInput(format!("Failed to parse the 'from_url' URL: {}", url))
                 })?;
 
                 if xorurl_encoder.content_type() == SafeContentType::Wallet {
                     Ok(url)
                 } else {
                     Err(Error::InvalidInput(format!(
-                        "The 'from' URL doesn't target a Key or Wallet, it is: {:?} ({})",
+                        "The 'from_url' URL doesn't target a Key or Wallet, it is: {:?} ({})",
                         xorurl_encoder.content_type(),
                         xorurl_encoder.data_type()
                     )))
                 }
             }
             None => Err(Error::InvalidInput(
-                "A \"<from_url>\" Wallet is required until default wallets have been configured."
+                "A 'from_url' Wallet is required until default wallets have been configured."
                     .to_string(),
             )),
         }?;

--- a/src/api/xorurl.rs
+++ b/src/api/xorurl.rs
@@ -11,6 +11,7 @@ use super::{Error, ResultReturn};
 use log::debug;
 use multibase::{decode, encode, Base};
 use safe_nd::{XorName, XOR_NAME_LEN};
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
 const SAFE_URL_PROTOCOL: &str = "safe://";
@@ -24,7 +25,7 @@ pub type XorUrl = String;
 // We encode the content type that a XOR-URL is targetting, this allows the consumer/user to
 // treat the content in particular ways when the content requires it.
 // TODO: support MIME types
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub enum SafeContentType {
     Raw = 0x0000,
     Wallet = 0x0001,
@@ -41,7 +42,7 @@ impl std::fmt::Display for SafeContentType {
 // We also encode the native SAFE data type where the content is being stored on the SAFE Network,
 // this allows us to fetch the targetted data using the corresponding API, regardless of the
 // data that is being held which is identified by the SafeContentType instead.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub enum SafeDataType {
     CoinBalance = 0x00,
     PublishedImmutableData = 0x01,

--- a/src/api/xorurl.rs
+++ b/src/api/xorurl.rs
@@ -10,8 +10,6 @@ use super::helpers::get_subnames_host_path_and_version;
 use super::{Error, ResultReturn};
 use log::debug;
 use multibase::{decode, encode, Base};
-use rand::rngs::OsRng;
-use rand_core::RngCore;
 use safe_nd::{XorName, XOR_NAME_LEN};
 use std::fmt;
 
@@ -34,6 +32,12 @@ pub enum SafeContentType {
     NrsMapContainer = 0x0003,
 }
 
+impl std::fmt::Display for SafeContentType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
 // We also encode the native SAFE data type where the content is being stored on the SAFE Network,
 // this allows us to fetch the targetted data using the corresponding API, regardless of the
 // data that is being held which is identified by the SafeContentType instead.
@@ -54,13 +58,6 @@ impl std::fmt::Display for SafeDataType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self)
     }
-}
-
-pub fn create_random_xorname() -> XorName {
-    let mut os_rng = OsRng::new().unwrap();
-    let mut xorname = XorName::default();
-    os_rng.fill_bytes(&mut xorname.0);
-    xorname
 }
 
 #[derive(Debug, Clone)]

--- a/src/api/xorurl.rs
+++ b/src/api/xorurl.rs
@@ -115,7 +115,7 @@ impl XorUrlEncoder {
             sub_names,
             content_version,
         );
-        xorurl_encoder.to_string(base)
+        xorurl_encoder.to_base(base)
     }
 
     pub fn from_url(xorurl: &str) -> ResultReturn<Self> {
@@ -259,7 +259,11 @@ impl XorUrlEncoder {
     // 32 bytes for XoR Name
     // and up to 8 bytes for type_tag
     // query param "v=" is treated as the content version
-    pub fn to_string(&self, base: &str) -> ResultReturn<String> {
+    pub fn to_string(&self) -> ResultReturn<String> {
+        self.to_base("")
+    }
+
+    pub fn to_base(&self, base: &str) -> ResultReturn<String> {
         // let's set the first byte with the XOR-URL format version
         let mut cid_vec: Vec<u8> = vec![XOR_URL_VERSION_1 as u8];
 
@@ -310,7 +314,7 @@ impl XorUrlEncoder {
 
 impl fmt::Display for XorUrlEncoder {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        let str = self.to_string("").map_err(|_| fmt::Error)?;
+        let str = self.to_string().map_err(|_| fmt::Error)?;
         write!(fmt, "{}", str)
     }
 }
@@ -369,7 +373,7 @@ fn test_xorurl_base64_encoding() {
     let base64_xorurl = "safe://mQACBTEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyRfRh";
     assert_eq!(xorurl, base64_xorurl);
     let xorurl_encoder = unwrap!(XorUrlEncoder::from_url(&base64_xorurl));
-    assert_eq!(base64_xorurl, unwrap!(xorurl_encoder.to_string("base64")));
+    assert_eq!(base64_xorurl, unwrap!(xorurl_encoder.to_base("base64")));
     assert_eq!("", xorurl_encoder.path());
     assert_eq!(XOR_URL_VERSION_1, xorurl_encoder.encoding_version());
     assert_eq!(xorname, xorurl_encoder.xorname());
@@ -446,7 +450,7 @@ fn test_xorurl_decoding_with_path() {
     let xorurl_encoder_with_path = unwrap!(XorUrlEncoder::from_url(&xorurl_with_path));
     assert_eq!(
         xorurl_with_path,
-        unwrap!(xorurl_encoder_with_path.to_string("base32z"))
+        unwrap!(xorurl_encoder_with_path.to_base("base32z"))
     );
     assert_eq!("/subfolder/file", xorurl_encoder_with_path.path());
     assert_eq!(
@@ -486,7 +490,7 @@ fn test_xorurl_decoding_with_subname() {
     let xorurl_encoder_with_subname = unwrap!(XorUrlEncoder::from_url(&xorurl_with_subname));
     assert_eq!(
         xorurl_with_subname,
-        unwrap!(xorurl_encoder_with_subname.to_string("base32z"))
+        unwrap!(xorurl_encoder_with_subname.to_base("base32z"))
     );
     assert_eq!("", xorurl_encoder_with_subname.path());
     assert_eq!(1, xorurl_encoder_with_subname.encoding_version());

--- a/src/api/xorurl.rs
+++ b/src/api/xorurl.rs
@@ -234,7 +234,7 @@ impl XorUrlEncoder {
 
     #[allow(dead_code)]
     pub fn set_path(&mut self, path: &str) {
-        if path.starts_with('/') {
+        if path.is_empty() || path.starts_with('/') {
             self.path = path.to_string();
         } else {
             self.path = format!("/{}", path);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,7 +29,7 @@ struct CmdArgs {
     // /// The account's Root Container address
     // #[structopt(long = "root", raw(global = "true"))]
     // root: bool,
-    /// Output data serlialisation. Currently only supported 'json'
+    /// Output data serialisation. Currently only supported 'json'
     #[structopt(short = "o", long = "output", raw(global = "true"))]
     output_fmt: Option<String>,
     /// Sets JSON as output serialisation format (alias of '--output json')
@@ -81,8 +81,8 @@ pub fn run() -> Result<(), String> {
             if OutputFmt::Pretty == output_fmt {
                 println!("Key pair generated:");
             }
-            println!("pk={}", key_pair.pk);
-            println!("sk={}", key_pair.sk);
+            println!("pk = {}", key_pair.pk);
+            println!("sk = {}", key_pair.sk);
             Ok(())
         }
         SubCommands::Update {} => {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -53,7 +53,7 @@ pub fn run() -> Result<(), String> {
     // Let's first get all the arguments passed in
     let args = CmdArgs::from_args();
 
-    let mut safe = Safe::new(args.xorurl_base.clone().unwrap_or_else(|| "".to_string()));
+    let mut safe = Safe::new(&args.xorurl_base.clone().unwrap_or_else(|| "".to_string()));
 
     let output_fmt = if args.output_json {
         OutputFmt::Json

--- a/src/subcommands/files.rs
+++ b/src/subcommands/files.rs
@@ -153,7 +153,7 @@ fn print_json_output(
     let url = match XorUrlEncoder::from_url(&xorurl) {
         Ok(mut xorurl_encoder) => {
             xorurl_encoder.set_content_version(Some(version));
-            xorurl_encoder.to_string("")?
+            xorurl_encoder.to_string()?
         }
         Err(_) => xorurl,
     };

--- a/src/subcommands/keys.rs
+++ b/src/subcommands/keys.rs
@@ -88,7 +88,7 @@ pub fn create_new_key(
     pk: Option<String>,
     output_fmt: OutputFmt,
 ) -> Result<(String, Option<BlsKeyPair>), String> {
-    let (xorname, key_pair) = if preload_test_coins {
+    let (xorurl, key_pair) = if preload_test_coins {
         if cfg!(not(feature = "mock-network")) && cfg!(not(feature = "scl-mock")) {
             warn!("'--test-coins' flag is not supported since it's only available for \"mock-network\" feature");
             return Err("'--test-coins' flag is not supported since it's only available for \"mock-network\" feature".to_string());
@@ -115,9 +115,9 @@ pub fn create_new_key(
     };
 
     if OutputFmt::Pretty == output_fmt {
-        println!("New Key created at: \"{}\"", xorname);
+        println!("New Key created at: \"{}\"", xorurl);
     } else {
-        println!("xorurl = {}", xorname);
+        println!("xorurl = {}", xorurl);
     }
 
     if let Some(pair) = &key_pair {
@@ -128,5 +128,5 @@ pub fn create_new_key(
         println!("sk = {}", pair.sk);
     }
 
-    Ok((xorname, key_pair))
+    Ok((xorurl, key_pair))
 }

--- a/src/subcommands/keys.rs
+++ b/src/subcommands/keys.rs
@@ -116,16 +116,23 @@ pub fn create_new_key(
 
     if OutputFmt::Pretty == output_fmt {
         println!("New Key created at: \"{}\"", xorurl);
-    } else {
-        println!("xorurl = {}", xorurl);
-    }
-
-    if let Some(pair) = &key_pair {
-        if OutputFmt::Pretty == output_fmt {
+        if let Some(pair) = &key_pair {
             println!("Key pair generated:");
+            println!("pk = {}", pair.pk);
+            println!("sk = {}", pair.sk);
         }
-        println!("pk = {}", pair.pk);
-        println!("sk = {}", pair.sk);
+    } else if let Some(pair) = &key_pair {
+        println!(
+            "{}",
+            serde_json::to_string(&(&xorurl, pair))
+                .unwrap_or_else(|_| "Failed to serialise output to json".to_string())
+        );
+    } else {
+        println!(
+            "{}",
+            serde_json::to_string(&xorurl)
+                .unwrap_or_else(|_| "Failed to serialise output to json".to_string())
+        );
     }
 
     Ok((xorurl, key_pair))

--- a/src/subcommands/wallet.rs
+++ b/src/subcommands/wallet.rs
@@ -109,7 +109,7 @@ pub fn wallet_commander(
             secret,
         }) => {
             // create wallet
-            let wallet_xorname = safe.wallet_create()?;
+            let wallet_xorurl = safe.wallet_create()?;
 
             if !no_balance {
                 // get or create keypair
@@ -129,13 +129,13 @@ pub fn wallet_commander(
                 };
 
                 // insert and set as default
-                safe.wallet_insert(&wallet_xorname, name, true, &sk)?;
+                safe.wallet_insert(&wallet_xorurl, name, true, &sk)?;
             }
 
             if OutputFmt::Pretty == output_fmt {
-                println!("Wallet created at: \"{}\"", &wallet_xorname);
+                println!("Wallet created at: \"{}\"", wallet_xorurl);
             } else {
-                println!("{}", &wallet_xorname);
+                println!("{}", wallet_xorurl);
             }
             Ok(())
         }

--- a/tests/cli_cat.rs
+++ b/tests/cli_cat.rs
@@ -47,6 +47,7 @@ fn calling_safe_cat_xorurl_url_with_version() {
     // let's sync with another file so we get a new version, and a different content in the file
     let mut xorurl_encoder = unwrap!(XorUrlEncoder::from_url(&container_xorurl));
     xorurl_encoder.set_path("/test.md");
+    xorurl_encoder.set_content_version(None);
     let mut cmd = Command::cargo_bin(CLI).unwrap();
     cmd.args(&vec![
         "files",
@@ -99,7 +100,7 @@ fn calling_safe_cat_nrsurl_with_version() {
         "create",
         &nrsurl,
         "-l",
-        &container_xorurl
+        &container_xorurl,
     )
     .read()
     .unwrap();
@@ -114,6 +115,7 @@ fn calling_safe_cat_nrsurl_with_version() {
     // let's sync with another file so we get a new version, and a different content in the file
     let mut xorurl_encoder = unwrap!(XorUrlEncoder::from_url(&container_xorurl));
     xorurl_encoder.set_path("/test.md");
+    xorurl_encoder.set_content_version(None);
     let mut cmd = Command::cargo_bin(CLI).unwrap();
     cmd.args(&vec![
         "files",

--- a/tests/cli_cat.rs
+++ b/tests/cli_cat.rs
@@ -53,35 +53,35 @@ fn calling_safe_cat_xorurl_url_with_version() {
         "files",
         "sync",
         ANOTHER_FILE,
-        &unwrap!(xorurl_encoder.to_string("")),
+        &unwrap!(xorurl_encoder.to_string()),
     ])
     .assert()
     .success();
 
     xorurl_encoder.set_content_version(None);
     let mut cmd = Command::cargo_bin(CLI).unwrap();
-    cmd.args(&vec!["cat", &unwrap!(xorurl_encoder.to_string(""))])
+    cmd.args(&vec!["cat", &unwrap!(xorurl_encoder.to_string())])
         .assert()
         .stdout(predicate::str::contains(ANOTHER_FILE_CONTENT))
         .success();
 
     xorurl_encoder.set_content_version(Some(0));
     let mut cmd = Command::cargo_bin(CLI).unwrap();
-    cmd.args(&vec!["cat", &unwrap!(xorurl_encoder.to_string(""))])
+    cmd.args(&vec!["cat", &unwrap!(xorurl_encoder.to_string())])
         .assert()
         .stdout(predicate::str::contains(TEST_FILE_CONTENT))
         .success();
 
     xorurl_encoder.set_content_version(Some(1));
     let mut cmd = Command::cargo_bin(CLI).unwrap();
-    cmd.args(&vec!["cat", &unwrap!(xorurl_encoder.to_string(""))])
+    cmd.args(&vec!["cat", &unwrap!(xorurl_encoder.to_string())])
         .assert()
         .stdout(predicate::str::contains(ANOTHER_FILE_CONTENT))
         .success();
 
     xorurl_encoder.set_content_version(Some(2));
     let mut cmd = Command::cargo_bin(CLI).unwrap();
-    cmd.args(&vec!["cat", &unwrap!(xorurl_encoder.to_string(""))])
+    cmd.args(&vec!["cat", &unwrap!(xorurl_encoder.to_string())])
         .assert()
         .failure();
 }
@@ -121,7 +121,7 @@ fn calling_safe_cat_nrsurl_with_version() {
         "files",
         "sync",
         ANOTHER_FILE,
-        &unwrap!(xorurl_encoder.to_string("")),
+        &unwrap!(xorurl_encoder.to_string()),
     ])
     .assert()
     .success();

--- a/tests/cli_files.rs
+++ b/tests/cli_files.rs
@@ -278,12 +278,15 @@ fn calling_safe_files_removed_sync() {
     assert_eq!(processed_files.len(), 5);
 
     // let's first try with --dry-run and they should not be removed
+    let mut xorurl_encoder = unwrap!(XorUrlEncoder::from_url(&files_container_xor));
+    xorurl_encoder.set_content_version(None);
+    let files_container_no_version = unwrap!(xorurl_encoder.to_string(""));
     let sync_cmd_output_dry_run = cmd!(
         get_bin_location(),
         "files",
         "sync",
         TEST_EMPTY_FOLDER, // rather than removing the files we pass an empty folder path
-        &files_container_xor,
+        &files_container_no_version,
         "--recursive",
         "--delete",
         "--dry-run",
@@ -292,7 +295,6 @@ fn calling_safe_files_removed_sync() {
     .read()
     .unwrap();
 
-    let mut xorurl_encoder = unwrap!(XorUrlEncoder::from_url(&files_container_xor));
     xorurl_encoder.set_content_version(Some(1));
     let files_container_v1 = unwrap!(xorurl_encoder.to_string(""));
     let (target, processed_files) = parse_files_put_or_sync_output(&sync_cmd_output_dry_run);
@@ -312,7 +314,7 @@ fn calling_safe_files_removed_sync() {
         "files",
         "sync",
         TEST_EMPTY_FOLDER, // rather than removing the files we pass an empty folder path
-        &files_container_xor,
+        &files_container_no_version,
         "--recursive",
         "--delete",
         "--json",
@@ -441,12 +443,15 @@ fn files_sync_and_fetch_with_version() {
         parse_files_put_or_sync_output(&files_container_output);
     assert_eq!(processed_files.len(), 5);
 
+    let mut xorurl_encoder = unwrap!(XorUrlEncoder::from_url(&files_container_xor));
+    xorurl_encoder.set_content_version(None);
+    let files_container_no_version = unwrap!(xorurl_encoder.to_string(""));
     let sync_cmd_output = cmd!(
         get_bin_location(),
         "files",
         "sync",
         TEST_EMPTY_FOLDER, // rather than removing the files we pass an empty folder path
-        &files_container_xor,
+        &files_container_no_version,
         "--recursive",
         "--delete",
         "--json",
@@ -454,7 +459,6 @@ fn files_sync_and_fetch_with_version() {
     .read()
     .unwrap();
 
-    let mut xorurl_encoder = unwrap!(XorUrlEncoder::from_url(&files_container_xor));
     xorurl_encoder.set_content_version(Some(1));
     let files_container_v1 = unwrap!(xorurl_encoder.to_string(""));
     let (target, processed_files) = parse_files_put_or_sync_output(&sync_cmd_output);

--- a/tests/cli_files.rs
+++ b/tests/cli_files.rs
@@ -88,7 +88,7 @@ fn calling_safe_files_put_recursive_and_set_dest_path() {
     let file_cat = cmd!(
         get_bin_location(),
         "cat",
-        &unwrap!(xorurl_encoder.to_string(""))
+        &unwrap!(xorurl_encoder.to_string())
     )
     .read()
     .unwrap();
@@ -98,7 +98,7 @@ fn calling_safe_files_put_recursive_and_set_dest_path() {
     let subfile_cat = cmd!(
         get_bin_location(),
         "cat",
-        &unwrap!(xorurl_encoder.to_string(""))
+        &unwrap!(xorurl_encoder.to_string())
     )
     .read()
     .unwrap();
@@ -161,7 +161,7 @@ fn calling_safe_files_put_recursive_with_slash() {
     let file_cat = cmd!(
         get_bin_location(),
         "cat",
-        &unwrap!(xorurl_encoder.to_string(""))
+        &unwrap!(xorurl_encoder.to_string())
     )
     .read()
     .unwrap();
@@ -172,7 +172,7 @@ fn calling_safe_files_put_recursive_with_slash() {
     let subfile_cat = cmd!(
         get_bin_location(),
         "cat",
-        &unwrap!(xorurl_encoder.to_string(""))
+        &unwrap!(xorurl_encoder.to_string())
     )
     .read()
     .unwrap();
@@ -201,7 +201,7 @@ fn calling_safe_files_put_recursive_without_slash() {
     let file_cat = cmd!(
         get_bin_location(),
         "cat",
-        &unwrap!(xorurl_encoder.to_string(""))
+        &unwrap!(xorurl_encoder.to_string())
     )
     .read()
     .unwrap();
@@ -212,7 +212,7 @@ fn calling_safe_files_put_recursive_without_slash() {
     let subfile_cat = cmd!(
         get_bin_location(),
         "cat",
-        &unwrap!(xorurl_encoder.to_string(""))
+        &unwrap!(xorurl_encoder.to_string())
     )
     .read()
     .unwrap();
@@ -253,7 +253,7 @@ fn calling_safe_files_sync() {
     let synced_file_cat = cmd!(
         get_bin_location(),
         "cat",
-        &unwrap!(xorurl_encoder.to_string(""))
+        &unwrap!(xorurl_encoder.to_string())
     )
     .read()
     .unwrap();
@@ -280,7 +280,7 @@ fn calling_safe_files_removed_sync() {
     // let's first try with --dry-run and they should not be removed
     let mut xorurl_encoder = unwrap!(XorUrlEncoder::from_url(&files_container_xor));
     xorurl_encoder.set_content_version(None);
-    let files_container_no_version = unwrap!(xorurl_encoder.to_string(""));
+    let files_container_no_version = unwrap!(xorurl_encoder.to_string());
     let sync_cmd_output_dry_run = cmd!(
         get_bin_location(),
         "files",
@@ -296,7 +296,7 @@ fn calling_safe_files_removed_sync() {
     .unwrap();
 
     xorurl_encoder.set_content_version(Some(1));
-    let files_container_v1 = unwrap!(xorurl_encoder.to_string(""));
+    let files_container_v1 = unwrap!(xorurl_encoder.to_string());
     let (target, processed_files) = parse_files_put_or_sync_output(&sync_cmd_output_dry_run);
     assert_eq!(target, files_container_v1);
     assert_eq!(processed_files.len(), 5);
@@ -331,13 +331,13 @@ fn calling_safe_files_removed_sync() {
     let synced_file_cat = cmd!(
         get_bin_location(),
         "cat",
-        &unwrap!(xorurl_encoder.to_string("")),
+        &unwrap!(xorurl_encoder.to_string()),
         "--json"
     )
     .read()
     .unwrap();
     let (xorurl, files_map) = parse_cat_files_container_output(&synced_file_cat);
-    assert_eq!(xorurl, unwrap!(xorurl_encoder.to_string("")));
+    assert_eq!(xorurl, unwrap!(xorurl_encoder.to_string()));
     assert_eq!(files_map.len(), 0);
 }
 
@@ -393,7 +393,7 @@ fn calling_safe_files_put_recursive_with_slash_then_sync_after_modifications() {
     let file_cat = cmd!(
         get_bin_location(),
         "cat",
-        &unwrap!(xorurl_encoder.to_string(""))
+        &unwrap!(xorurl_encoder.to_string())
     )
     .read()
     .unwrap();
@@ -445,7 +445,7 @@ fn files_sync_and_fetch_with_version() {
 
     let mut xorurl_encoder = unwrap!(XorUrlEncoder::from_url(&files_container_xor));
     xorurl_encoder.set_content_version(None);
-    let files_container_no_version = unwrap!(xorurl_encoder.to_string(""));
+    let files_container_no_version = unwrap!(xorurl_encoder.to_string());
     let sync_cmd_output = cmd!(
         get_bin_location(),
         "files",
@@ -460,7 +460,7 @@ fn files_sync_and_fetch_with_version() {
     .unwrap();
 
     xorurl_encoder.set_content_version(Some(1));
-    let files_container_v1 = unwrap!(xorurl_encoder.to_string(""));
+    let files_container_v1 = unwrap!(xorurl_encoder.to_string());
     let (target, processed_files) = parse_files_put_or_sync_output(&sync_cmd_output);
     assert_eq!(target, files_container_v1);
     assert_eq!(processed_files.len(), 5);
@@ -475,7 +475,7 @@ fn files_sync_and_fetch_with_version() {
 
     // but in version 0 of the FilesContainer all files should still be there
     xorurl_encoder.set_content_version(Some(0));
-    let files_container_v0 = unwrap!(xorurl_encoder.to_string(""));
+    let files_container_v0 = unwrap!(xorurl_encoder.to_string());
     let cat_container_v0 = cmd!(get_bin_location(), "cat", &files_container_v0, "--json")
         .read()
         .unwrap();
@@ -503,7 +503,7 @@ fn files_sync_and_fetch_with_nrsurl_and_nrs_update() {
 
     let mut xorurl_encoder = unwrap!(XorUrlEncoder::from_url(&files_container_xor));
     xorurl_encoder.set_content_version(Some(0));
-    let files_container_v0 = &unwrap!(xorurl_encoder.to_string(""));
+    let files_container_v0 = &unwrap!(xorurl_encoder.to_string());
     let nrsurl = format!("safe://{}", get_random_nrs_string());
 
     let _ = cmd!(
@@ -572,7 +572,7 @@ fn files_sync_and_fetch_without_nrs_update() {
     assert_eq!(processed_files.len(), 5);
     let mut xorurl_encoder = unwrap!(XorUrlEncoder::from_url(&files_container_xor));
     xorurl_encoder.set_content_version(Some(0));
-    let files_container_v0 = unwrap!(xorurl_encoder.to_string(""));
+    let files_container_v0 = unwrap!(xorurl_encoder.to_string());
     let nrsurl = format!("safe://{}", get_random_nrs_string());
 
     let _ = cmd!(
@@ -606,7 +606,7 @@ fn files_sync_and_fetch_without_nrs_update() {
     // now all files should be gone in version 1 of the FilesContainer
     let mut xorurl_encoder = unwrap!(XorUrlEncoder::from_url(&files_container_xor));
     xorurl_encoder.set_content_version(Some(1));
-    let files_container_v1 = unwrap!(xorurl_encoder.to_string(""));
+    let files_container_v1 = unwrap!(xorurl_encoder.to_string());
     let cat_container_v1 = cmd!(get_bin_location(), "cat", &files_container_v1, "--json")
         .read()
         .unwrap();

--- a/tests/cli_keys.rs
+++ b/tests/cli_keys.rs
@@ -50,8 +50,8 @@ fn calling_safe_keypair() {
     let mut cmd = Command::cargo_bin(CLI).unwrap();
     cmd.args(&vec!["keypair"])
         .assert()
-        .stdout(predicate::str::contains("sk="))
-        .stdout(predicate::str::contains("pk="))
+        .stdout(predicate::str::contains("sk = "))
+        .stdout(predicate::str::contains("pk = "))
         .success();
 }
 
@@ -61,8 +61,8 @@ fn calling_safe_keypair_pretty() {
     cmd.args(&vec!["keypair"])
         .assert()
         .stdout(predicate::str::contains("Key pair generated:"))
-        .stdout(predicate::str::contains("sk="))
-        .stdout(predicate::str::contains("pk="))
+        .stdout(predicate::str::contains("sk = "))
+        .stdout(predicate::str::contains("pk = "))
         .success();
 }
 

--- a/tests/cli_nrs.rs
+++ b/tests/cli_nrs.rs
@@ -132,7 +132,7 @@ fn calling_safe_nrs_put_no_top_default_fetch() {
     let (container_xorurl, _map) = upload_test_folder();
     let mut xorurl_encoder = unwrap!(XorUrlEncoder::from_url(&container_xorurl));
     xorurl_encoder.set_path("/test.md");
-    let link = unwrap!(xorurl_encoder.to_string(""));
+    let link = unwrap!(xorurl_encoder.to_string());
     let _nrs_creation = cmd!(
         get_bin_location(),
         "nrs",

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -8,6 +8,7 @@
 
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
+use safe_cli::BlsKeyPair;
 use std::env;
 
 pub const CLI: &str = "safe";
@@ -30,7 +31,6 @@ pub fn get_bin_location() -> String {
 
 #[allow(dead_code)]
 pub fn create_preload_and_get_keys(preload: &str) -> (String, String) {
-    // KEY_FROM
     let pk_command_result = cmd!(
         get_bin_location(),
         "keys",
@@ -43,14 +43,9 @@ pub fn create_preload_and_get_keys(preload: &str) -> (String, String) {
     .read()
     .unwrap();
 
-    let mut lines = pk_command_result.lines();
-    let pk_xor_line = lines.next().unwrap();
-    let pk_xor = &pk_xor_line["xorurl = ".len()..];
-    let _pk = lines.next().unwrap();
-    let sk_line = lines.next().unwrap();
-    let sk = &sk_line["sk = ".len()..];
-
-    (pk_xor.to_string(), sk.to_string())
+    let (xorurl, pair): (String, BlsKeyPair) = serde_json::from_str(&pk_command_result)
+        .expect("Failed to parse output of `safe files sync`");
+    (xorurl, pair.sk)
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
- Add a validation to files and nrs commands and APIs, to make sure NRS name provided to nrs create/add, as well as target URL provided to files sync commands are unversioned
- Implementation of an additional level for the `--info` argument in the `cat` command to display the content of the NRS map, e.g.:
```
Resolved using NRS Map:
PublicName: "mypubname"
Container XOR-URL: safe://hnyydyiec84yks653p87zycggzyh691a8y49n5n7srh4awjpzaayhfgnunbqh
Native data type: PublishedSeqAppendOnlyData
Type tag: 1500
XOR name: 0x50c3e80ab7b7969fb7030c6b839efcb0706be2d8bb627358a25b7c601c298531
Version: 4
+------------------------+----------------------+----------------------+--------------------------------------------------------------------------+
| NRS name/subname       | Created              | Modified             | Link                                                                     |
+------------------------+----------------------+----------------------+--------------------------------------------------------------------------+
| mypubname              | 2019-08-12T15:28:16Z | 2019-08-12T15:28:16Z | safe://hnyynysfouck3wgmssrt75nixhrdf47skzo86wfbx91uzjh46aqt6mzn6nbnc?v=0 |
+------------------------+----------------------+----------------------+--------------------------------------------------------------------------+
| subname.mypubname      | 2019-08-12T15:29:42Z | 2019-08-12T15:29:42Z | safe://hnyynyi37x4gjs7y815y3q8dmkaugnrf3ma4ezuehr3adzibgo116o6zehbnc?v=0 |
+------------------------+----------------------+----------------------+--------------------------------------------------------------------------+
| test.subname.mypubname | 2019-08-12T15:30:00Z | 2019-08-12T15:30:00Z | safe://hbyyyydisscu7ynfxnyknqmi94bcikkn4d1tnfsadbzu8fgktb8rdn1h6a        |
+------------------------+----------------------+----------------------+--------------------------------------------------------------------------+
```