### PR TITLE
Use Nightly Build for Safe Auth

### DIFF
--- a/resources/test-scripts/all-tests
+++ b/resources/test-scripts/all-tests
@@ -1,53 +1,71 @@
 #!/bin/bash
 
-if [ -z $RANDOM_PORT_NUMBER ]
-then
-  export RANDOM_PORT_NUMBER=41805
-fi
-
-if [ -z $SAFE_MOCK_VAULT_PATH ]
-then
-  export SAFE_MOCK_VAULT_PATH=~/safe_auth
-fi
-
-function setup_safe_auth() {
-    rm -rf $SAFE_MOCK_VAULT_PATH
-    git clone https://github.com/maidsafe/safe-authenticator-cli.git $SAFE_MOCK_VAULT_PATH
-    (
-        cd $SAFE_MOCK_VAULT_PATH
-        SAFE_AUTH_SECRET=a SAFE_AUTH_PASSWORD=b cargo run --features=mock-network -- -i nonsense || true
-        echo "Launching safe_auth daemon on port:" $RANDOM_PORT_NUMBER
-        SAFE_AUTH_SECRET=a SAFE_AUTH_PASSWORD=b cargo run --features=mock-network -- --daemon $RANDOM_PORT_NUMBER --allow-all-auth &
-        sleep 15
-        cd -
-    )
-}
-
 set -e -x
 
-# first setup auth CLI
-setup_safe_auth
+auth_bin_name="safe_auth"
+[[ -z $RANDOM_PORT_NUMBER ]] && export RANDOM_PORT_NUMBER=41805
+[[ -z $SAFE_MOCK_VAULT_PATH ]] && export SAFE_MOCK_VAULT_PATH=~/safe_auth
 
-# check formatting
+function download_safe_auth_nightly() {
+    uname_output=$(uname -a)
+    case $uname_output in
+        Linux*)
+            curl -L -O https://safe-authenticator-cli.s3.amazonaws.com/safe_authenticator_cli-nightly-x86_64-unknown-linux-gnu.tar
+            tar xvf safe_authenticator_cli-nightly-x86_64-unknown-linux-gnu.tar
+            rm safe_authenticator_cli-nightly-x86_64-unknown-linux-gnu.tar
+            ;;
+        Darwin*)
+            curl -L -O https://safe-authenticator-cli.s3.amazonaws.com/safe_authenticator_cli-nightly-x86_64-apple-darwin.tar
+            tar xvf safe_authenticator_cli-nightly-x86_64-apple-darwin.tar
+            rm safe_authenticator_cli-nightly-x86_64-apple-darwin.tar
+            ;;
+        MSYS_NT*)
+            curl -L -O https://safe-authenticator-cli.s3.amazonaws.com/safe_authenticator_cli-nightly-x86_64-pc-windows-gnu.tar
+            tar xvf safe_authenticator_cli-nightly-x86_64-pc-windows-gnu.tar
+            rm safe_authenticator_cli-nightly-x86_64-pc-windows-gnu.tar
+            auth_bin_name="safe_auth.exe"
+            ;;
+        *)
+            echo "Platform not supported. Please extend to support this platform."
+            exit 1
+    esac
+    rm -rf $SAFE_MOCK_VAULT_PATH
+    mkdir $SAFE_MOCK_VAULT_PATH
+    mv $auth_bin_name $SAFE_MOCK_VAULT_PATH
+}
+
+function run_safe_auth() {
+    cd $SAFE_MOCK_VAULT_PATH
+    ls -al
+    SAFE_AUTH_SECRET=a SAFE_AUTH_PASSWORD=b ./$auth_bin_name -i nonsense || true
+    echo "Launching safe_auth daemon on port:" $RANDOM_PORT_NUMBER
+    SAFE_AUTH_SECRET=a SAFE_AUTH_PASSWORD=b ./$auth_bin_name \
+        --daemon $RANDOM_PORT_NUMBER --allow-all-auth &
+    sleep 15
+    cd -
+}
+
+function run_unit_tests() {
+    cargo test --release --features=scl-mock -- --test-threads=1
+    cargo test --lib --release --features=mock-network,fake-auth -- --test-threads=1
+    cargo test --doc --release --features=mock-network,fake-auth -- --test-threads=1
+}
+
+function run_integration_tests() {
+    # now let's run the integration tests but without fake-auth, using the safe_auth CLI to get credentials
+    # get auth credentials which will be then used by the integration tests to connect to mock-network
+    echo "Sending auth request to port:" $RANDOM_PORT_NUMBER
+    cargo run --release --features=mock-network -- auth --port $RANDOM_PORT_NUMBER
+
+    cargo test --release --features=mock-network --test cli_cat -- --test-threads=1
+    cargo test --release --features=mock-network --test cli_files -- --test-threads=1
+    cargo test --release --features=mock-network --test cli_keys -- --test-threads=1
+    cargo test --release --features=mock-network --test cli_wallet -- --test-threads=1
+    cargo test --release --features=mock-network --test cli_nrs -- --test-threads=1
+}
+
+download_safe_auth_nightly
+run_safe_auth
 cargo fmt -- --check
-
-# run tests with CLI's own mock
-cargo test --release --features=scl-mock -- --test-threads=1
-
-# run the unit tests with SCL's mock-network, with fake-auth
-cargo test --lib --release --features=mock-network,fake-auth -- --test-threads=1
-
-# run the doc tests now with SCL's mock-network, with fake-auth
-cargo test --doc --release --features=mock-network,fake-auth -- --test-threads=1
-
-# now let's run the integration tests but without fake-auth, using the safe_auth CLI to get credentials
-# get auth credentials which will be then used by the integration tests to connect to mock-network
-echo "Sending auth request to port:" $RANDOM_PORT_NUMBER
-cargo run --release --features=mock-network -- auth --port $RANDOM_PORT_NUMBER
-
-# we can now run each of the integration tests suite
-cargo test --release --features=mock-network --test cli_cat -- --test-threads=1
-cargo test --release --features=mock-network --test cli_files -- --test-threads=1
-cargo test --release --features=mock-network --test cli_keys -- --test-threads=1
-cargo test --release --features=mock-network --test cli_wallet -- --test-threads=1
-cargo test --release --features=mock-network --test cli_nrs -- --test-threads=1
+run_unit_tests
+run_integration_tests


### PR DESCRIPTION
Rather than recompile the authenticator we can pull the nightly release and run that.
