### PR TITLE
Release Process Issues and Community Feedback

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ properties([
         string(name: 'ARTIFACTS_BUCKET', defaultValue: 'safe-jenkins-build-artifacts'),
         string(name: 'CACHE_BRANCH', defaultValue: 'master'),
         string(name: 'DEPLOY_BUCKET', defaultValue: 'safe-cli'),
-        string(name: 'CLEAN_BUILD_BRANCH', defaultValue: 'PR-231')
+        string(name: 'CLEAN_BUILD_BRANCH', defaultValue: 'master')
     ])
 ])
 

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,22 @@ The development version uses a mocked SAFE network, which allows you to work aga
 endef
 export GITHUB_RELEASE_DESCRIPTION
 
+build-clean:
+	rm -rf artifacts
+	mkdir artifacts
+ifeq ($(UNAME_S),Linux)
+	docker run --name "safe-cli-build-${UUID}" -v "${PWD}":/usr/src/safe-cli:Z \
+		-u ${USER_ID}:${GROUP_ID} \
+		maidsafe/safe-cli-build:build \
+		bash -c "rm -rf /target/release && cargo build --release"
+	docker cp "safe-cli-build-${UUID}":/target .
+	docker rm "safe-cli-build-${UUID}"
+else
+	rm -rf target
+	cargo build --release
+endif
+	find target/release -maxdepth 1 -type f -exec cp '{}' artifacts \;
+
 build:
 	rm -rf artifacts
 	mkdir artifacts
@@ -53,6 +69,15 @@ else
 	cargo build --release --features=mock-network
 endif
 	find target/release -maxdepth 1 -type f -exec cp '{}' artifacts \;
+
+strip-artifacts:
+ifeq ($(OS),Windows_NT)
+	find artifacts -name "*.dll" -exec strip -x '{}' \;
+else ifeq ($(UNAME_S),Darwin)
+	find artifacts -name "*.dylib" -exec strip -x '{}' \;
+else
+	find artifacts -name "*.so" -exec strip '{}' \;
+endif
 
 build-container:
 	rm -rf target/

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,6 @@ UNAME_S := $(shell uname -s)
 PWD := $(shell echo $$PWD)
 UUID := $(shell uuidgen | sed 's/-//g')
 S3_BUCKET := safe-jenkins-build-artifacts
-S3_LINUX_DEPLOY_URL := https://safe-cli.s3.amazonaws.com/safe_cli-${SAFE_CLI_VERSION}-x86_64-unknown-linux-gnu-dev.tar
-S3_WIN_DEPLOY_URL := https://safe-cli.s3.amazonaws.com/safe_cli-${SAFE_CLI_VERSION}-x86_64-pc-windows-gnu-dev.tar
-S3_MACOS_DEPLOY_URL := https://safe-cli.s3.amazonaws.com/safe_cli-${SAFE_CLI_VERSION}-x86_64-apple-darwin-dev.tar
 SAFE_AUTH_DEFAULT_PORT := 41805
 GITHUB_REPO_OWNER := maidsafe
 GITHUB_REPO_NAME := safe-cli
@@ -196,40 +193,46 @@ endif
 	rm -rf ${MOCK_VAULT_PATH}
 
 package-commit_hash-artifacts-for-deploy:
-	rm -f *.tar
+	rm -f *.zip
 	rm -rf deploy
 	mkdir -p deploy/dev
 	mkdir -p deploy/release
-	tar -C artifacts/linux/release -cvf safe_cli-$$(git rev-parse --short HEAD)-x86_64-unknown-linux-gnu.tar safe
-	tar -C artifacts/win/release -cvf safe_cli-$$(git rev-parse --short HEAD)-x86_64-pc-windows-gnu.tar safe.exe
-	tar -C artifacts/macos/release -cvf safe_cli-$$(git rev-parse --short HEAD)-x86_64-apple-darwin.tar safe
-	tar -C artifacts/linux/dev -cvf safe_cli-$$(git rev-parse --short HEAD)-x86_64-unknown-linux-gnu-dev.tar safe
-	tar -C artifacts/win/dev -cvf safe_cli-$$(git rev-parse --short HEAD)-x86_64-pc-windows-gnu-dev.tar safe.exe
-	tar -C artifacts/macos/dev -cvf safe_cli-$$(git rev-parse --short HEAD)-x86_64-apple-darwin-dev.tar safe
-	mv safe_cli-$$(git rev-parse --short HEAD)-x86_64-unknown-linux-gnu.tar deploy/release
-	mv safe_cli-$$(git rev-parse --short HEAD)-x86_64-pc-windows-gnu.tar deploy/release
-	mv safe_cli-$$(git rev-parse --short HEAD)-x86_64-apple-darwin.tar deploy/release
-	mv safe_cli-$$(git rev-parse --short HEAD)-x86_64-unknown-linux-gnu-dev.tar deploy/dev
-	mv safe_cli-$$(git rev-parse --short HEAD)-x86_64-pc-windows-gnu-dev.tar deploy/dev
-	mv safe_cli-$$(git rev-parse --short HEAD)-x86_64-apple-darwin-dev.tar deploy/dev
+	zip safe_cli-$$(git rev-parse --short HEAD)-x86_64-unknown-linux-gnu.zip artifacts/linux/release/safe
+	zip safe_cli-$$(git rev-parse --short HEAD)-x86_64-pc-windows-gnu.zip artifacts/win/release/safe.exe
+	zip safe_cli-$$(git rev-parse --short HEAD)-x86_64-apple-darwin.zip artifacts/macos/release/safe
+	zip safe_cli-$$(git rev-parse --short HEAD)-x86_64-unknown-linux-gnu-dev.zip artifacts/linux/dev/safe
+	zip safe_cli-$$(git rev-parse --short HEAD)-x86_64-pc-windows-gnu-dev.zip artifacts/win/dev/safe.exe
+	zip safe_cli-$$(git rev-parse --short HEAD)-x86_64-apple-darwin-dev.zip artifacts/macos/dev/safe
+	mv safe_cli-$$(git rev-parse --short HEAD)-x86_64-unknown-linux-gnu.zip deploy/release
+	mv safe_cli-$$(git rev-parse --short HEAD)-x86_64-pc-windows-gnu.zip deploy/release
+	mv safe_cli-$$(git rev-parse --short HEAD)-x86_64-apple-darwin.zip deploy/release
+	mv safe_cli-$$(git rev-parse --short HEAD)-x86_64-unknown-linux-gnu-dev.zip deploy/dev
+	mv safe_cli-$$(git rev-parse --short HEAD)-x86_64-pc-windows-gnu-dev.zip deploy/dev
+	mv safe_cli-$$(git rev-parse --short HEAD)-x86_64-apple-darwin-dev.zip deploy/dev
 
 package-version-artifacts-for-deploy:
-	rm -f *.tar
+	rm -f *.zip
 	rm -rf deploy
 	mkdir -p deploy/dev
 	mkdir -p deploy/release
-	tar -C artifacts/linux/release -cvf safe_cli-${SAFE_CLI_VERSION}-x86_64-unknown-linux-gnu.tar safe
-	tar -C artifacts/win/release -cvf safe_cli-${SAFE_CLI_VERSION}-x86_64-pc-windows-gnu.tar safe.exe
-	tar -C artifacts/macos/release -cvf safe_cli-${SAFE_CLI_VERSION}-x86_64-apple-darwin.tar safe
-	tar -C artifacts/linux/dev -cvf safe_cli-${SAFE_CLI_VERSION}-x86_64-unknown-linux-gnu-dev.tar safe
-	tar -C artifacts/win/dev -cvf safe_cli-${SAFE_CLI_VERSION}-x86_64-pc-windows-gnu-dev.tar safe.exe
-	tar -C artifacts/macos/dev -cvf safe_cli-${SAFE_CLI_VERSION}-x86_64-apple-darwin-dev.tar safe
-	mv safe_cli-${SAFE_CLI_VERSION}-x86_64-unknown-linux-gnu.tar deploy/release
-	mv safe_cli-${SAFE_CLI_VERSION}-x86_64-pc-windows-gnu.tar deploy/release
-	mv safe_cli-${SAFE_CLI_VERSION}-x86_64-apple-darwin.tar deploy/release
-	mv safe_cli-${SAFE_CLI_VERSION}-x86_64-unknown-linux-gnu-dev.tar deploy/dev
-	mv safe_cli-${SAFE_CLI_VERSION}-x86_64-pc-windows-gnu-dev.tar deploy/dev
-	mv safe_cli-${SAFE_CLI_VERSION}-x86_64-apple-darwin-dev.tar deploy/dev
+	( \
+		cd deploy/release; \
+		zip safe_cli-${SAFE_CLI_VERSION}-x86_64-unknown-linux-gnu.zip \
+			../../artifacts/linux/release/safe; \
+		zip safe_cli-${SAFE_CLI_VERSION}-x86_64-pc-windows-gnu.zip \
+			../../artifacts/win/release/safe.exe; \
+		zip safe_cli-${SAFE_CLI_VERSION}-x86_64-apple-darwin.zip \
+			../../artifacts/macos/release/safe; \
+	)
+	( \
+		cd deploy/dev; \
+		zip safe_cli-${SAFE_CLI_VERSION}-x86_64-unknown-linux-gnu-dev.zip \
+			../../artifacts/linux/dev/safe; \
+		zip safe_cli-${SAFE_CLI_VERSION}-x86_64-pc-windows-gnu-dev.zip \
+			../../artifacts/win/dev/safe.exe; \
+		zip safe_cli-${SAFE_CLI_VERSION}-x86_64-apple-darwin-dev.zip \
+			../../artifacts/macos/dev/safe; \
+	)
 
 deploy-github-release:
 ifndef GITHUB_TOKEN
@@ -246,20 +249,20 @@ endif
 		--user ${GITHUB_REPO_OWNER} \
 		--repo ${GITHUB_REPO_NAME} \
 		--tag ${SAFE_CLI_VERSION} \
-		--name "safe_cli-${SAFE_CLI_VERSION}-x86_64-unknown-linux-gnu.tar" \
-		--file deploy/release/safe_cli-${SAFE_CLI_VERSION}-x86_64-unknown-linux-gnu.tar;
+		--name "safe_cli-${SAFE_CLI_VERSION}-x86_64-unknown-linux-gnu.zip" \
+		--file deploy/release/safe_cli-${SAFE_CLI_VERSION}-x86_64-unknown-linux-gnu.zip;
 	github-release upload \
 		--user ${GITHUB_REPO_OWNER} \
 		--repo ${GITHUB_REPO_NAME} \
 		--tag ${SAFE_CLI_VERSION} \
-		--name "safe_cli-${SAFE_CLI_VERSION}-x86_64-pc-windows-gnu.tar" \
-		--file deploy/release/safe_cli-${SAFE_CLI_VERSION}-x86_64-pc-windows-gnu.tar;
+		--name "safe_cli-${SAFE_CLI_VERSION}-x86_64-pc-windows-gnu.zip" \
+		--file deploy/release/safe_cli-${SAFE_CLI_VERSION}-x86_64-pc-windows-gnu.zip;
 	github-release upload \
 		--user ${GITHUB_REPO_OWNER} \
 		--repo ${GITHUB_REPO_NAME} \
 		--tag ${SAFE_CLI_VERSION} \
-		--name "safe_cli-${SAFE_CLI_VERSION}-x86_64-apple-darwin.tar" \
-		--file deploy/release/safe_cli-${SAFE_CLI_VERSION}-x86_64-apple-darwin.tar;
+		--name "safe_cli-${SAFE_CLI_VERSION}-x86_64-apple-darwin.zip" \
+		--file deploy/release/safe_cli-${SAFE_CLI_VERSION}-x86_64-apple-darwin.zip;
 
 retrieve-cache:
 ifndef SAFE_CLI_BRANCH

--- a/Makefile
+++ b/Makefile
@@ -12,17 +12,6 @@ S3_MACOS_DEPLOY_URL := https://safe-cli.s3.amazonaws.com/safe_cli-${SAFE_CLI_VER
 SAFE_AUTH_DEFAULT_PORT := 41805
 GITHUB_REPO_OWNER := maidsafe
 GITHUB_REPO_NAME := safe-cli
-define GITHUB_RELEASE_DESCRIPTION
-Command line interface for the SAFE Network.
-
-There are also development versions of this release:
-[Linux](${S3_LINUX_DEPLOY_URL})
-[macOS](${S3_MACOS_DEPLOY_URL})
-[Windows](${S3_WIN_DEPLOY_URL})
-
-The development version uses a mocked SAFE network, which allows you to work against a file that mimics the network, where SafeCoins are created for local use.
-endef
-export GITHUB_RELEASE_DESCRIPTION
 
 build-clean:
 	rm -rf artifacts
@@ -252,7 +241,7 @@ endif
 		--repo ${GITHUB_REPO_NAME} \
 		--tag ${SAFE_CLI_VERSION} \
 		--name "safe-cli" \
-		--description "$$GITHUB_RELEASE_DESCRIPTION";
+		--description "$$(./resources/get_release_description.sh ${SAFE_CLI_VERSION})";
 	github-release upload \
 		--user ${GITHUB_REPO_OWNER} \
 		--repo ${GITHUB_REPO_NAME} \

--- a/Makefile
+++ b/Makefile
@@ -263,6 +263,12 @@ endif
 		--tag ${SAFE_CLI_VERSION} \
 		--name "safe_cli-${SAFE_CLI_VERSION}-x86_64-apple-darwin.zip" \
 		--file deploy/release/safe_cli-${SAFE_CLI_VERSION}-x86_64-apple-darwin.zip;
+	github-release upload \
+		--user ${GITHUB_REPO_OWNER} \
+		--repo ${GITHUB_REPO_NAME} \
+		--tag ${SAFE_CLI_VERSION} \
+		--name "safe_completion.sh" \
+		--file resources/safe_completion.sh
 
 retrieve-cache:
 ifndef SAFE_CLI_BRANCH

--- a/resources/get_release_description.sh
+++ b/resources/get_release_description.sh
@@ -17,6 +17,14 @@ There are also development versions of this release:
 
 The development version uses a mocked SAFE network, which allows you to work against a file that mimics the network, where SafeCoins are created for local use.
 
+## Bash Autocompletion
+
+If you are using Bash on Linux, you can get auto completion for `safe` by doing the following:
+```
+curl -L SAFE_COMPLETION_URL > ~/.safe_completion
+echo "source ~/.safe_completion" >> ~/.bashrc
+```
+
 ## SHA-256 checksums for release versions:
 ```
 Linux
@@ -35,9 +43,10 @@ WIN_CHECKSUM
 * [SAFE vault](https://github.com/maidsafe/safe_vault/releases/latest/)
 EOF
 
-s3_linux_deploy_url="https:\/\/safe-cli.s3.amazonaws.com\/safe_cli-${version}-x86_64-unknown-linux-gnu-dev.zip"
-s3_win_deploy_url="https:\/\/safe-cli.s3.amazonaws.com\/safe_cli-${version}-x86_64-pc-windows-gnu-dev.zip"
-s3_macos_deploy_url="https:\/\/safe-cli.s3.amazonaws.com\/safe_cli-${version}-x86_64-apple-darwin-dev.zip"
+safe_completion_url="https:\/\/github.com\/maidsafe\/safe-cli\/releases\/download\/$version\/safe_completion.sh"
+s3_linux_deploy_url="https:\/\/safe-cli.s3.amazonaws.com\/safe_cli-$version-x86_64-unknown-linux-gnu-dev.zip"
+s3_win_deploy_url="https:\/\/safe-cli.s3.amazonaws.com\/safe_cli-$version-x86_64-pc-windows-gnu-dev.zip"
+s3_macos_deploy_url="https:\/\/safe-cli.s3.amazonaws.com\/safe_cli-$version-x86_64-apple-darwin-dev.zip"
 linux_checksum=$(sha256sum \
     "./deploy/release/safe_cli-$version-x86_64-unknown-linux-gnu.zip" | \
     awk '{ print $1 }')
@@ -51,6 +60,7 @@ win_checksum=$(sha256sum \
 release_description=$(sed "s/S3_LINUX_DEPLOY_URL/$s3_linux_deploy_url/g" <<< "$release_description")
 release_description=$(sed "s/S3_MACOS_DEPLOY_URL/$s3_macos_deploy_url/g" <<< "$release_description")
 release_description=$(sed "s/S3_WIN_DEPLOY_URL/$s3_win_deploy_url/g" <<< "$release_description")
+release_description=$(sed "s/SAFE_COMPLETION_URL/$safe_completion_url/g" <<< "$release_description")
 release_description=$(sed "s/LINUX_CHECKSUM/$linux_checksum/g" <<< "$release_description")
 release_description=$(sed "s/MACOS_CHECKSUM/$macos_checksum/g" <<< "$release_description")
 release_description=$(sed "s/WIN_CHECKSUM/$win_checksum/g" <<< "$release_description")

--- a/resources/get_release_description.sh
+++ b/resources/get_release_description.sh
@@ -35,17 +35,17 @@ WIN_CHECKSUM
 * [SAFE vault](https://github.com/maidsafe/safe_vault/releases/latest/)
 EOF
 
-s3_linux_deploy_url="https:\/\/safe-cli.s3.amazonaws.com\/safe_cli-${version}-x86_64-unknown-linux-gnu-dev.tar"
-s3_win_deploy_url="https:\/\/safe-cli.s3.amazonaws.com\/safe_cli-${version}-x86_64-pc-windows-gnu-dev.tar"
-s3_macos_deploy_url="https:\/\/safe-cli.s3.amazonaws.com\/safe_cli-${version}-x86_64-apple-darwin-dev.tar"
+s3_linux_deploy_url="https:\/\/safe-cli.s3.amazonaws.com\/safe_cli-${version}-x86_64-unknown-linux-gnu-dev.zip"
+s3_win_deploy_url="https:\/\/safe-cli.s3.amazonaws.com\/safe_cli-${version}-x86_64-pc-windows-gnu-dev.zip"
+s3_macos_deploy_url="https:\/\/safe-cli.s3.amazonaws.com\/safe_cli-${version}-x86_64-apple-darwin-dev.zip"
 linux_checksum=$(sha256sum \
-    "./deploy/release/safe_cli-$version-x86_64-unknown-linux-gnu.tar" | \
+    "./deploy/release/safe_cli-$version-x86_64-unknown-linux-gnu.zip" | \
     awk '{ print $1 }')
 macos_checksum=$(sha256sum \
-    "./deploy/release/safe_cli-$version-x86_64-apple-darwin.tar" | \
+    "./deploy/release/safe_cli-$version-x86_64-apple-darwin.zip" | \
     awk '{ print $1 }')
 win_checksum=$(sha256sum \
-    "./deploy/release/safe_cli-$version-x86_64-pc-windows-gnu.tar" | \
+    "./deploy/release/safe_cli-$version-x86_64-pc-windows-gnu.zip" | \
     awk '{ print $1 }')
 
 release_description=$(sed "s/S3_LINUX_DEPLOY_URL/$s3_linux_deploy_url/g" <<< "$release_description")

--- a/resources/get_release_description.sh
+++ b/resources/get_release_description.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+version=$1
+if [[ -z "$version" ]]; then
+    echo "You must supply a version number."
+    exit 1
+fi
+
+# The single quotes around EOF is to stop attempted variable and backtick expansion.
+read -r -d '' release_description << 'EOF'
+Command line interface for the SAFE Network.
+
+There are also development versions of this release:
+[Linux](S3_LINUX_DEPLOY_URL)
+[macOS](S3_MACOS_DEPLOY_URL)
+[Windows](S3_WIN_DEPLOY_URL)
+
+The development version uses a mocked SAFE network, which allows you to work against a file that mimics the network, where SafeCoins are created for local use.
+
+## SHA-256 checksums for release versions:
+```
+Linux
+LINUX_CHECKSUM
+
+macOS
+MACOS_CHECKSUM
+
+Windows
+WIN_CHECKSUM
+```
+
+## Related Links
+* [SAFE Authenticator CLI](https://github.com/maidsafe/safe-authenticator-cli/releases/latest/)
+* [SAFE Browser PoC](https://github.com/maidsafe/safe_browser/releases/)
+* [SAFE vault](https://github.com/maidsafe/safe_vault/releases/latest/)
+EOF
+
+s3_linux_deploy_url="https:\/\/safe-cli.s3.amazonaws.com\/safe_cli-${version}-x86_64-unknown-linux-gnu-dev.tar"
+s3_win_deploy_url="https:\/\/safe-cli.s3.amazonaws.com\/safe_cli-${version}-x86_64-pc-windows-gnu-dev.tar"
+s3_macos_deploy_url="https:\/\/safe-cli.s3.amazonaws.com\/safe_cli-${version}-x86_64-apple-darwin-dev.tar"
+linux_checksum=$(sha256sum \
+    "./deploy/release/safe_cli-$version-x86_64-unknown-linux-gnu.tar" | \
+    awk '{ print $1 }')
+macos_checksum=$(sha256sum \
+    "./deploy/release/safe_cli-$version-x86_64-apple-darwin.tar" | \
+    awk '{ print $1 }')
+win_checksum=$(sha256sum \
+    "./deploy/release/safe_cli-$version-x86_64-pc-windows-gnu.tar" | \
+    awk '{ print $1 }')
+
+release_description=$(sed "s/S3_LINUX_DEPLOY_URL/$s3_linux_deploy_url/g" <<< "$release_description")
+release_description=$(sed "s/S3_MACOS_DEPLOY_URL/$s3_macos_deploy_url/g" <<< "$release_description")
+release_description=$(sed "s/S3_WIN_DEPLOY_URL/$s3_win_deploy_url/g" <<< "$release_description")
+release_description=$(sed "s/LINUX_CHECKSUM/$linux_checksum/g" <<< "$release_description")
+release_description=$(sed "s/MACOS_CHECKSUM/$macos_checksum/g" <<< "$release_description")
+release_description=$(sed "s/WIN_CHECKSUM/$win_checksum/g" <<< "$release_description")
+echo "$release_description"

--- a/resources/safe_completion.sh
+++ b/resources/safe_completion.sh
@@ -1,0 +1,268 @@
+#tested on Linux Mint 19.1
+#examples/documentation:
+#1: - complete -F _dkms dkms 
+#   - type _dkms
+#2: - https://linux.die.net/man/1/bash: 'Programmable Completion'-chapter
+#5: - https://debian-administration.org/article/317/An_introduction_to_bash_completion_part_2
+
+_safe_get_subcmds()
+{
+  #cmd=$1
+  #subcmd=$2 (if given)
+
+  #if subcmds stays empty, then the caller of this function know to not call this fu. again
+  #no local variable (see fu _safe() below)
+  subcmds=""
+  case $1 in
+    auth)
+      case $2 in
+        clear|help)
+          :
+          ;;
+        *)
+          subcmds="clear help"
+          ;;
+      esac;
+      ;;
+    cat)
+      #-i|--info autocomplete -> only once?
+      comp_opts+=" safe:// -i --info"
+      ;;
+    container)
+      case $2 in
+        add|create)
+          #--link safe://... --name <container> #not sure if container=safe://...
+          comp_opts+=" --link"
+          ;;
+        edit)
+          #--key <key>
+          comp_opts+=" --key"
+          ;;
+        help)
+          :
+          ;;
+        *)
+          subcmds="add create edit help"
+          :
+          ;;
+      esac
+      ;;
+    files)
+      case $2 in
+        help)
+          :
+          ;;
+        put)
+          #<location: local>
+          comp_file="-f"
+          #<dest: safe://...>
+          comp_opts+=" safe:// -r --recursive"
+          ;;
+        sync)
+          #<location: local>
+          comp_file="-f"
+          #<target: safe://...>
+          comp_opts+=" safe:// -r --recursive"
+          ;;
+        *)
+          subcmds="help put sync"
+          ;;
+      esac
+      ;;
+    keys)
+      case $2 in
+        balance)
+          #--keyurl <keyurl> --sk <secret>"
+          comp_opts+="--keyurl --sk"
+          ;;
+        
+        create)
+          #--pay-with <pay_with> --pk <pk> --preload <preload>"
+          comp_opts+="-w --pay-with --pk --preload"
+          ;;
+        help)
+          :
+          ;;
+        *)
+          subcmds="balance create help"    
+          ;;
+      esac
+      ;;
+    nrs)
+      case $2 in
+        add)
+          #-l|--link safe://... <name: do nothing>
+          comp_opts+=" -l --link safe:// -t --direct --default"
+          ;;
+        create)
+          #-l|--link safe://... <name: do nothing>
+          comp_opts+=" -l --link safe:// -t --direct"
+          ;;
+        help)
+          :
+          ;;
+        remove)
+          #<name: do nothing>
+          :
+          ;;
+        *)
+          subcmds="add create help remove"
+          ;;
+      esac
+      ;;
+    safe-id)
+      case $2 in
+        create|update)
+          #--email <email> --name <name> --surname <surname> --wallet <wallet> --website <website>
+          comp_opts+=" --email --name --surname --wallet --website"
+          ;;
+        help)
+          ;;
+        *)
+          subcmds="create help update"
+          ;;
+      esac
+      ;;
+    wallet)
+      case $2 in
+        #<target: safe://...>
+        balance)
+          comp_opts+=" safe://"
+          ;;
+        create)
+          #--keyurl <keyurl> --name <name> -w|--pay-with <pay_with> --preload <preload> --sk <secret_key>
+          comp_opts+=" --no-balance --test-coins --keyurl --name -w --pay-with --preload --sk"
+          ;;
+        help)
+          :
+          ;;
+        insert)
+          #<target: safe://...> --keyurl <keyurl> --name <name> -w|--pay-with <pay_with> --sk <secret_key>
+          comp_opts+=" safe:// --default --keyurl --name -w --pay-with --sk"
+          ;;
+        transfer)
+          #<amount> <to: safe://...> <from: safe://...>
+          comp_opts+=" safe://"
+          ;;
+        *)
+          subcmds="balance create help insert transfer"
+          ;;
+      esac
+      ;;
+    #There shouldn't be any other option be possible
+    help|keypair|update)
+    #*)
+      :
+      ;;
+  esac;
+}
+_safe()
+{
+  local cur sregex
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  #necessary for ':' in safe://<tab> -> google this and COMP_WORDBREAK for more details
+  _get_comp_words_by_ref -n : cur
+  COMPREPLY=()
+
+  sregex="^safe://.*/"
+
+  if [[ "$cur" =~ $sregex ]] ; then
+    #    0123456789...   89..: offset 7
+    #    prefix
+    #           suffix
+    #cur=safe://spath/ssubpath/...
+    local suffix=${cur:7}
+    local spath=${suffix%%/*}
+
+    local xor_urls=($(safe cat safe://$spath/ 2> /dev/null|grep "^| \/"|awk '{print substr($2,2)}'|sort -u))
+    #full_xor_urls=$(safe cat $cur 2> /dev/null|grep "^| \/"|awk '{print substr($2,2)}'|sort -u)
+    local full_xor_urls=()
+    for el in "${xor_urls[@]}"; do
+      full_xor_urls+=("safe://$spath/${el}")
+    done
+
+    #for some reason expanding of array in compgen doesn't work, after flattening it works
+    local full_xor_urls_flat=${full_xor_urls[@]}
+
+    local tmp_compreply=($(compgen -W "$full_xor_urls_flat" -- "$cur"))
+
+    local _cr_el cur_len=${#cur}
+    #make assiocative compreply:
+    # - to get rid of duplicates, without needing sort
+    # - automatically local
+    declare -A as_compreply=()
+    for cr_el in ${tmp_compreply[@]} ; do
+      #get rid of first part so we can get rid of everything after correct '/'-char
+      _cr_el=${cr_el:$cur_len}
+
+      #get rid of everything after first '/'-char, if present
+      if [[ $_cr_el =~ "/" ]] ; then
+        _cr_el=${_cr_el/\/*/\/}
+      fi
+
+      #prepend first part again
+      _cr_el=${cr_el::$cur_len}$_cr_el
+
+      #used assiociative array->overwrite already existing entries
+      as_compreply["$_cr_el"]=1
+    done
+    COMPREPLY=("${!as_compreply[@]}")
+
+    #if COMPREPLY returns 1 element and last char is '/' (->dir): append no nospace
+    [[ ${#COMPREPLY[@]} == 1 ]] && [[ "${COMPREPLY[0]: -1}" == '/' ]] && compopt -o nospace
+
+    #necessary for ':' in safe://<tab> -> google this and COMP_WORDBREAK for more details
+    __ltrim_colon_completions "$cur"
+  else
+    local cmds flags long_flags opts long_opts comp_opts _cmd cmd subcmds subcmd cur i comp_file
+    #local prev
+    
+    cmds="auth cat container files help keypair keys nrs safe-id update wallet"
+
+    #flags can come everywhere
+    flags="-n -h -V"
+    long_flags="--dry-run --help --json --version"
+    #default options and flags can come everywhere
+    opts="-o"
+    long_opts="--output --xorurl"
+
+    cmd=""
+    subcmds=""
+
+    for ((i=1; i < COMP_CWORD; i++ ))
+    do
+      if [ -z "$cmd" ]; then
+        for _cmd in $cmds; do
+          if [[ ${COMP_WORDS[i]} == $_cmd ]] ; then
+            cmd=$_cmd
+            #sets subcmds sys var
+            _safe_get_subcmds $cmd
+          fi
+        done
+      elif [ -n "$subcmds" ] ; then
+        _safe_get_subcmds $cmd "${COMP_WORDS[i]}"
+      fi
+    done;
+    SREGEX="^safe://.*/"
+
+    if [ -z "$cmd" ] ; then
+      comp_opts+=" "$cmds
+      comp_opts+=$flags
+      comp_opts+=" "$long_flags
+      comp_opts+=" "$opts
+      comp_opts+=" "$long_opts
+    fi
+    if [ -n "$subcmds" ] ; then
+      comp_opts+=" "$subcmds
+    fi
+
+    COMPREPLY=($(compgen $comp_file -W "$comp_opts" -- $cur))
+    #necessary for ':' in safe://<tab> -> google this and COMP_WORDBREAK for more details
+    __ltrim_colon_completions "$cur"
+    #We don't want a space appended after safe://
+    #sometimes return is not safe:// but // (':' causes split into 'safe', ':' and '//'...)
+    [[ "$COMPREPLY" == *// ]] && compopt -o nospace
+  fi
+}
+
+complete -F _safe safe


### PR DESCRIPTION
Hi Gabriel,

This is mainly related to user feedback and a couple of other things:

* Do a full clean build as opposed to using a cache when we're building `master` 
* Run `strip` against the release artifacts
* Distribute with zips rather than tars
* Automatically add sha-256 checksums for the release builds
* Add the community contributed safe_completion.sh as a release asset and provide some instructions in the description for setting it up

[Here](https://github.com/jacderida/safe-cli/releases/tag/0.2.3) is a new example release on my fork.

Cheers,

Chris