### PR TITLE
Produce tar.gz Assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,6 +233,12 @@ package-version-artifacts-for-deploy:
 		zip -j safe_cli-${SAFE_CLI_VERSION}-x86_64-apple-darwin-dev.zip \
 			../../artifacts/macos/dev/safe; \
 	)
+	tar -C artifacts/linux/release \
+		-zcvf safe_cli-${SAFE_CLI_VERSION}-x86_64-unknown-linux-gnu.tar.gz safe
+	tar -C artifacts/win/release \
+		-zcvf safe_cli-${SAFE_CLI_VERSION}-x86_64-pc-windows-gnu.tar.gz safe.exe
+	tar -C artifacts/macos/release \
+		-zcvf safe_cli-${SAFE_CLI_VERSION}-x86_64-apple-darwin.tar.gz safe
 
 deploy-github-release:
 ifndef GITHUB_TOKEN
@@ -263,6 +269,23 @@ endif
 		--tag ${SAFE_CLI_VERSION} \
 		--name "safe_cli-${SAFE_CLI_VERSION}-x86_64-apple-darwin.zip" \
 		--file deploy/release/safe_cli-${SAFE_CLI_VERSION}-x86_64-apple-darwin.zip;
+	github-release upload \
+		--user ${GITHUB_REPO_OWNER} \
+		--repo ${GITHUB_REPO_NAME} \
+		--tag ${SAFE_CLI_VERSION} \
+		--name "safe_cli-${SAFE_CLI_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+		--file deploy/release/safe_cli-${SAFE_CLI_VERSION}-x86_64-unknown-linux-gnu.zip;
+	github-release upload \
+		--user ${GITHUB_REPO_OWNER} \
+		--repo ${GITHUB_REPO_NAME} \
+		--tag ${SAFE_CLI_VERSION} \
+		--name "safe_cli-${SAFE_CLI_VERSION}-x86_64-pc-windows-gnu.tar.gz" \
+		--file deploy/release/safe_cli-${SAFE_CLI_VERSION}-x86_64-pc-windows-gnu.zip;
+	github-release upload \
+		--user ${GITHUB_REPO_OWNER} \
+		--repo ${GITHUB_REPO_NAME} \
+		--tag ${SAFE_CLI_VERSION} \
+		--name "safe_cli-${SAFE_CLI_VERSION}-x86_64-apple-darwin.tar.gz" \
 	github-release upload \
 		--user ${GITHUB_REPO_OWNER} \
 		--repo ${GITHUB_REPO_NAME} \

--- a/Makefile
+++ b/Makefile
@@ -217,20 +217,20 @@ package-version-artifacts-for-deploy:
 	mkdir -p deploy/release
 	( \
 		cd deploy/release; \
-		zip safe_cli-${SAFE_CLI_VERSION}-x86_64-unknown-linux-gnu.zip \
+		zip -j safe_cli-${SAFE_CLI_VERSION}-x86_64-unknown-linux-gnu.zip \
 			../../artifacts/linux/release/safe; \
-		zip safe_cli-${SAFE_CLI_VERSION}-x86_64-pc-windows-gnu.zip \
+		zip -j safe_cli-${SAFE_CLI_VERSION}-x86_64-pc-windows-gnu.zip \
 			../../artifacts/win/release/safe.exe; \
-		zip safe_cli-${SAFE_CLI_VERSION}-x86_64-apple-darwin.zip \
+		zip -j safe_cli-${SAFE_CLI_VERSION}-x86_64-apple-darwin.zip \
 			../../artifacts/macos/release/safe; \
 	)
 	( \
 		cd deploy/dev; \
-		zip safe_cli-${SAFE_CLI_VERSION}-x86_64-unknown-linux-gnu-dev.zip \
+		zip -j safe_cli-${SAFE_CLI_VERSION}-x86_64-unknown-linux-gnu-dev.zip \
 			../../artifacts/linux/dev/safe; \
-		zip safe_cli-${SAFE_CLI_VERSION}-x86_64-pc-windows-gnu-dev.zip \
+		zip -j safe_cli-${SAFE_CLI_VERSION}-x86_64-pc-windows-gnu-dev.zip \
 			../../artifacts/win/dev/safe.exe; \
-		zip safe_cli-${SAFE_CLI_VERSION}-x86_64-apple-darwin-dev.zip \
+		zip -j safe_cli-${SAFE_CLI_VERSION}-x86_64-apple-darwin-dev.zip \
 			../../artifacts/macos/dev/safe; \
 	)
 

--- a/Makefile
+++ b/Makefile
@@ -58,11 +58,11 @@ endif
 
 strip-artifacts:
 ifeq ($(OS),Windows_NT)
-	find artifacts -name "*.dll" -exec strip -x '{}' \;
+	find artifacts -name "safe.exe" -exec strip -x '{}' \;
 else ifeq ($(UNAME_S),Darwin)
-	find artifacts -name "*.dylib" -exec strip -x '{}' \;
+	find artifacts -name "safe" -exec strip -x '{}' \;
 else
-	find artifacts -name "*.so" -exec strip '{}' \;
+	find artifacts -name "safe" -exec strip '{}' \;
 endif
 
 build-container:
@@ -223,6 +223,12 @@ package-version-artifacts-for-deploy:
 			../../artifacts/win/release/safe.exe; \
 		zip -j safe_cli-${SAFE_CLI_VERSION}-x86_64-apple-darwin.zip \
 			../../artifacts/macos/release/safe; \
+		tar -C ../../artifacts/linux/release \
+			-zcvf safe_cli-${SAFE_CLI_VERSION}-x86_64-unknown-linux-gnu.tar.gz safe; \
+		tar -C ../../artifacts/win/release \
+			-zcvf safe_cli-${SAFE_CLI_VERSION}-x86_64-pc-windows-gnu.tar.gz safe.exe; \
+		tar -C ../../artifacts/macos/release \
+			-zcvf safe_cli-${SAFE_CLI_VERSION}-x86_64-apple-darwin.tar.gz safe; \
 	)
 	( \
 		cd deploy/dev; \
@@ -233,12 +239,6 @@ package-version-artifacts-for-deploy:
 		zip -j safe_cli-${SAFE_CLI_VERSION}-x86_64-apple-darwin-dev.zip \
 			../../artifacts/macos/dev/safe; \
 	)
-	tar -C artifacts/linux/release \
-		-zcvf safe_cli-${SAFE_CLI_VERSION}-x86_64-unknown-linux-gnu.tar.gz safe
-	tar -C artifacts/win/release \
-		-zcvf safe_cli-${SAFE_CLI_VERSION}-x86_64-pc-windows-gnu.tar.gz safe.exe
-	tar -C artifacts/macos/release \
-		-zcvf safe_cli-${SAFE_CLI_VERSION}-x86_64-apple-darwin.tar.gz safe
 
 deploy-github-release:
 ifndef GITHUB_TOKEN
@@ -274,18 +274,19 @@ endif
 		--repo ${GITHUB_REPO_NAME} \
 		--tag ${SAFE_CLI_VERSION} \
 		--name "safe_cli-${SAFE_CLI_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
-		--file deploy/release/safe_cli-${SAFE_CLI_VERSION}-x86_64-unknown-linux-gnu.zip;
+		--file deploy/release/safe_cli-${SAFE_CLI_VERSION}-x86_64-unknown-linux-gnu.tar.gz;
 	github-release upload \
 		--user ${GITHUB_REPO_OWNER} \
 		--repo ${GITHUB_REPO_NAME} \
 		--tag ${SAFE_CLI_VERSION} \
 		--name "safe_cli-${SAFE_CLI_VERSION}-x86_64-pc-windows-gnu.tar.gz" \
-		--file deploy/release/safe_cli-${SAFE_CLI_VERSION}-x86_64-pc-windows-gnu.zip;
+		--file deploy/release/safe_cli-${SAFE_CLI_VERSION}-x86_64-pc-windows-gnu.tar.gz;
 	github-release upload \
 		--user ${GITHUB_REPO_OWNER} \
 		--repo ${GITHUB_REPO_NAME} \
 		--tag ${SAFE_CLI_VERSION} \
 		--name "safe_cli-${SAFE_CLI_VERSION}-x86_64-apple-darwin.tar.gz" \
+		--file deploy/release/safe_cli-${SAFE_CLI_VERSION}-x86_64-apple-darwin.tar.gz;
 	github-release upload \
 		--user ${GITHUB_REPO_OWNER} \
 		--repo ${GITHUB_REPO_NAME} \

--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,6 @@ package-commit_hash-artifacts-for-deploy:
 	mv safe_cli-$$(git rev-parse --short HEAD)-x86_64-apple-darwin-dev.zip deploy/dev
 
 package-version-artifacts-for-deploy:
-	rm -f *.zip
 	rm -rf deploy
 	mkdir -p deploy/dev
 	mkdir -p deploy/release

--- a/resources/get_release_description.sh
+++ b/resources/get_release_description.sh
@@ -24,20 +24,23 @@ The development version uses a mocked SAFE network, allowing you to work against
 If you are using Bash on Linux, you can get autocompletion for `safe` by doing the following:
 ```
 curl -L SAFE_COMPLETION_URL > ~/.safe_completion
-chmod +x ~/..safe_completion
+chmod +x ~/.safe_completion
 echo "source ~/.safe_completion" >> ~/.bashrc
 ```
 
 ## SHA-256 checksums for release versions:
 ```
 Linux
-LINUX_CHECKSUM
+zip: ZIP_LINUX_CHECKSUM
+tar.gz: TAR_LINUX_CHECKSUM
 
 macOS
-MACOS_CHECKSUM
+zip: ZIP_MACOS_CHECKSUM
+tar.gz: TAR_MACOS_CHECKSUM
 
 Windows
-WIN_CHECKSUM
+zip: ZIP_WIN_CHECKSUM
+tar.gz: TAR_WIN_CHECKSUM
 ```
 
 ## Related Links
@@ -50,21 +53,33 @@ safe_completion_url="https:\/\/github.com\/maidsafe\/safe-cli\/releases\/downloa
 s3_linux_deploy_url="https:\/\/safe-cli.s3.amazonaws.com\/safe_cli-$version-x86_64-unknown-linux-gnu-dev.zip"
 s3_win_deploy_url="https:\/\/safe-cli.s3.amazonaws.com\/safe_cli-$version-x86_64-pc-windows-gnu-dev.zip"
 s3_macos_deploy_url="https:\/\/safe-cli.s3.amazonaws.com\/safe_cli-$version-x86_64-apple-darwin-dev.zip"
-linux_checksum=$(sha256sum \
+zip_linux_checksum=$(sha256sum \
     "./deploy/release/safe_cli-$version-x86_64-unknown-linux-gnu.zip" | \
     awk '{ print $1 }')
-macos_checksum=$(sha256sum \
+zip_macos_checksum=$(sha256sum \
     "./deploy/release/safe_cli-$version-x86_64-apple-darwin.zip" | \
     awk '{ print $1 }')
-win_checksum=$(sha256sum \
+zip_win_checksum=$(sha256sum \
     "./deploy/release/safe_cli-$version-x86_64-pc-windows-gnu.zip" | \
+    awk '{ print $1 }')
+tar_linux_checksum=$(sha256sum \
+    "./deploy/release/safe_cli-$version-x86_64-unknown-linux-gnu.tar.gz" | \
+    awk '{ print $1 }')
+tar_macos_checksum=$(sha256sum \
+    "./deploy/release/safe_cli-$version-x86_64-apple-darwin.tar.gz" | \
+    awk '{ print $1 }')
+tar_win_checksum=$(sha256sum \
+    "./deploy/release/safe_cli-$version-x86_64-pc-windows-gnu.tar.gz" | \
     awk '{ print $1 }')
 
 release_description=$(sed "s/S3_LINUX_DEPLOY_URL/$s3_linux_deploy_url/g" <<< "$release_description")
 release_description=$(sed "s/S3_MACOS_DEPLOY_URL/$s3_macos_deploy_url/g" <<< "$release_description")
 release_description=$(sed "s/S3_WIN_DEPLOY_URL/$s3_win_deploy_url/g" <<< "$release_description")
 release_description=$(sed "s/SAFE_COMPLETION_URL/$safe_completion_url/g" <<< "$release_description")
-release_description=$(sed "s/LINUX_CHECKSUM/$linux_checksum/g" <<< "$release_description")
-release_description=$(sed "s/MACOS_CHECKSUM/$macos_checksum/g" <<< "$release_description")
-release_description=$(sed "s/WIN_CHECKSUM/$win_checksum/g" <<< "$release_description")
+release_description=$(sed "s/ZIP_LINUX_CHECKSUM/$zip_linux_checksum/g" <<< "$release_description")
+release_description=$(sed "s/ZIP_MACOS_CHECKSUM/$zip_macos_checksum/g" <<< "$release_description")
+release_description=$(sed "s/ZIP_WIN_CHECKSUM/$zip_win_checksum/g" <<< "$release_description")
+release_description=$(sed "s/TAR_LINUX_CHECKSUM/$tar_linux_checksum/g" <<< "$release_description")
+release_description=$(sed "s/TAR_MACOS_CHECKSUM/$tar_macos_checksum/g" <<< "$release_description")
+release_description=$(sed "s/TAR_WIN_CHECKSUM/$tar_win_checksum/g" <<< "$release_description")
 echo "$release_description"

--- a/resources/get_release_description.sh
+++ b/resources/get_release_description.sh
@@ -10,18 +10,21 @@ fi
 read -r -d '' release_description << 'EOF'
 Command line interface for the SAFE Network.
 
+## Development Builds
+
 There are also development versions of this release:
 [Linux](S3_LINUX_DEPLOY_URL)
 [macOS](S3_MACOS_DEPLOY_URL)
 [Windows](S3_WIN_DEPLOY_URL)
 
-The development version uses a mocked SAFE network, which allows you to work against a file that mimics the network, where SafeCoins are created for local use.
+The development version uses a mocked SAFE network, allowing you to work against a file that mimics the network, where SafeCoins are created for local use.
 
 ## Bash Autocompletion
 
-If you are using Bash on Linux, you can get auto completion for `safe` by doing the following:
+If you are using Bash on Linux, you can get autocompletion for `safe` by doing the following:
 ```
 curl -L SAFE_COMPLETION_URL > ~/.safe_completion
+chmod +x ~/..safe_completion
 echo "source ~/.safe_completion" >> ~/.bashrc
 ```
 
@@ -40,7 +43,7 @@ WIN_CHECKSUM
 ## Related Links
 * [SAFE Authenticator CLI](https://github.com/maidsafe/safe-authenticator-cli/releases/latest/)
 * [SAFE Browser PoC](https://github.com/maidsafe/safe_browser/releases/)
-* [SAFE vault](https://github.com/maidsafe/safe_vault/releases/latest/)
+* [SAFE Vault](https://github.com/maidsafe/safe_vault/releases/latest/)
 EOF
 
 safe_completion_url="https:\/\/github.com\/maidsafe\/safe-cli\/releases\/download\/$version\/safe_completion.sh"


### PR DESCRIPTION
Adds a set of tar.gz assets and fixes another couple of little things.

[Example](https://github.com/jacderida/safe-cli/releases/tag/0.2.3) release on my fork.

Cheers,

Chris