### PR TITLE
"helpers"

### DIFF
--- a/safe-ffi/ffi/fetch.rs
+++ b/safe-ffi/ffi/fetch.rs
@@ -2,10 +2,10 @@ use super::ffi_structs::{
     files_map_into_repr_c, nrs_map_container_info_into_repr_c,
     wallet_spendable_balances_into_repr_c, FilesContainer, PublishedImmutableData, SafeKey, Wallet,
 };
-use super::helpers::to_c_str;
 use super::{ResultReturn, Safe};
 use ffi_utils::{catch_unwind_cb, from_c_str, FfiResult, OpaqueCtx};
 use safe_api::fetch::SafeData;
+use std::ffi::CString;
 use std::os::raw::{c_char, c_void};
 
 #[no_mangle]
@@ -37,7 +37,7 @@ pub unsafe extern "C" fn fetch(
                     resolved_from: nrs_map_container_info_into_repr_c(
                         &resolved_from.as_ref().unwrap(),
                     )?,
-                    media_type: to_c_str(media_type.clone().unwrap())?.as_ptr(),
+                    media_type: CString::new(media_type.clone().unwrap())?.as_ptr(),
                 };
                 o_published(user_data.0, &published_data);
             }

--- a/safe-ffi/ffi/ffi_structs.rs
+++ b/safe-ffi/ffi/ffi_structs.rs
@@ -1,4 +1,4 @@
-use super::helpers::{from_c_str_to_str_option, to_c_str};
+use super::helpers::from_c_str_to_str_option;
 use ffi_utils::{from_c_str, vec_into_raw_parts};
 use safe_api::files::{
     FileItem as NativeFileItem, FilesMap as NativeFilesMap, ProcessedFiles as NativeProcessedFiles,
@@ -93,8 +93,8 @@ pub unsafe fn xorurl_encoder_into_repr_c(
         type_tag: xorurl_encoder.type_tag(),
         data_type: xorurl_encoder.data_type() as u64,
         content_type: xorurl_encoder.content_type().value()?,
-        path: to_c_str(xorurl_encoder.path().to_string())?.as_ptr(),
-        sub_names: to_c_str(sub_names)?.as_ptr(),
+        path: CString::new(xorurl_encoder.path().to_string())?.as_ptr(),
+        sub_names: CString::new(sub_names)?.as_ptr(),
         // sub_names: sub_names, // Todo: update to String Vec
         // sub_names_len: xorurl_encoder.sub_names().len(),
         content_version: xorurl_encoder.content_version().unwrap_or_else(|| 0),
@@ -200,9 +200,9 @@ pub unsafe fn processed_files_into_repr_c(
 
     for (file_name, (file_meta_data, file_xorurl)) in map {
         vec.push(ProcessedFile {
-            file_name: to_c_str(file_name.to_string())?.as_ptr(),
-            file_meta_data: to_c_str(file_meta_data.to_string())?.as_ptr(),
-            file_xorurl: to_c_str(file_xorurl.to_string())?.as_ptr(),
+            file_name: CString::new(file_name.to_string())?.as_ptr(),
+            file_meta_data: CString::new(file_meta_data.to_string())?.as_ptr(),
+            file_xorurl: CString::new(file_xorurl.to_string())?.as_ptr(),
         })
     }
 
@@ -267,14 +267,14 @@ pub unsafe fn file_item_into_repr_c(
 
     for (file_meta_data, xorurl) in file_item_map {
         vec.push(FileItem {
-            file_meta_data: to_c_str(file_meta_data.to_string())?.as_ptr(),
-            xorurl: to_c_str(xorurl.to_string())?.as_ptr(),
+            file_meta_data: CString::new(file_meta_data.to_string())?.as_ptr(),
+            xorurl: CString::new(xorurl.to_string())?.as_ptr(),
         })
     }
 
     let (file_items, file_items_len, file_items_cap) = vec_into_raw_parts(vec);
     Ok(FileInfo {
-        file_name: to_c_str(file_name.to_string())?.as_ptr(),
+        file_name: CString::new(file_name.to_string())?.as_ptr(),
         file_items,
         file_items_len,
         file_items_cap,
@@ -329,9 +329,9 @@ pub unsafe fn processed_entries_into_repr_c(
 
     for (name, (action, link)) in entries {
         vec.push(ProcessedEntry {
-            name: to_c_str(name.to_string())?.as_ptr(),
-            action: to_c_str(action.to_string())?.as_ptr(),
-            link: to_c_str(link.to_string())?.as_ptr(),
+            name: CString::new(name.to_string())?.as_ptr(),
+            action: CString::new(action.to_string())?.as_ptr(),
+            link: CString::new(link.to_string())?.as_ptr(),
         })
     }
 
@@ -359,12 +359,12 @@ pub unsafe fn nrs_map_container_info_into_repr_c(
 ) -> ResultReturn<NrsMapContainerInfo> {
     let nrs_map_json = serde_json::to_string(&nrs_container_info.nrs_map)?;
     Ok(NrsMapContainerInfo {
-        public_name: to_c_str(nrs_container_info.public_name.clone())?.as_ptr(),
-        xorurl: to_c_str(nrs_container_info.xorurl.clone())?.as_ptr(),
+        public_name: CString::new(nrs_container_info.public_name.clone())?.as_ptr(),
+        xorurl: CString::new(nrs_container_info.xorurl.clone())?.as_ptr(),
         xorname: nrs_container_info.xorname.0,
         type_tag: nrs_container_info.type_tag,
         version: nrs_container_info.version,
-        nrs_map: to_c_str(nrs_map_json)?.as_ptr(),
+        nrs_map: CString::new(nrs_map_json)?.as_ptr(),
         data_type: nrs_container_info.data_type.clone() as u64,
     })
 }

--- a/safe-ffi/ffi/files.rs
+++ b/safe-ffi/ffi/files.rs
@@ -1,11 +1,12 @@
 use super::ffi_structs::{
     files_map_into_repr_c, processed_files_into_repr_c, FilesMap, ProcessedFiles,
 };
-use super::helpers::{from_c_str_to_str_option, to_c_str};
+use super::helpers::from_c_str_to_str_option;
 use ffi_utils::{
     catch_unwind_cb, from_c_str, vec_clone_from_raw_parts, FfiResult, OpaqueCtx, FFI_RESULT_OK,
 };
 use safe_api::{ResultReturn, Safe};
+use std::ffi::CString;
 use std::os::raw::{c_char, c_void};
 
 #[no_mangle]
@@ -30,7 +31,7 @@ pub unsafe extern "C" fn files_container_create(
         let destination = from_c_str_to_str_option(dest);
         let (xorurl, processed_files, files_map) =
             (*app).files_container_create(&location_str, destination, recursive, dry_run)?;
-        let xorurl_string = to_c_str(xorurl)?;
+        let xorurl_string = CString::new(xorurl)?;
         let ffi_files_map = files_map_into_repr_c(&files_map)?;
         let ffi_processed_files = processed_files_into_repr_c(&processed_files)?;
         o_cb(
@@ -196,7 +197,7 @@ pub unsafe extern "C" fn files_put_published_immutable(
         let media_type_str = from_c_str_to_str_option(media_type);
         let data_vec = vec_clone_from_raw_parts(data, data_len);
         let xorurl = (*app).files_put_published_immutable(&data_vec, media_type_str)?;
-        let xorurl_string = to_c_str(xorurl)?;
+        let xorurl_string = CString::new(xorurl)?;
         o_cb(user_data.0, FFI_RESULT_OK, xorurl_string.as_ptr());
         Ok(())
     })

--- a/safe-ffi/ffi/helpers.rs
+++ b/safe-ffi/ffi/helpers.rs
@@ -26,12 +26,6 @@ pub unsafe fn from_c_str_to_str_option(ptr: *const c_char) -> Option<&'static st
 }
 
 #[inline]
-pub unsafe fn to_c_str(native_string: String) -> Result<CString, Error> {
-    CString::new(native_string)
-        .map_err(|_| Error::StringError("Couldn't convert to string".to_string()))
-}
-
-#[inline]
 pub fn string_vec_to_c_str_str(argv: Vec<String>) -> Result<*const *const c_char, Error> {
     let cstr_argv: Vec<_> = argv
         .iter()

--- a/safe-ffi/ffi/keys.rs
+++ b/safe-ffi/ffi/keys.rs
@@ -1,7 +1,8 @@
 use super::ffi_structs::{bls_key_pair_into_repr_c, BlsKeyPair};
-use super::helpers::{from_c_str_to_str_option, to_c_str};
+use super::helpers::from_c_str_to_str_option;
 use ffi_utils::{catch_unwind_cb, from_c_str, FfiResult, OpaqueCtx, FFI_RESULT_OK};
 use safe_api::{ResultReturn, Safe};
+use std::ffi::CString;
 use std::os::raw::{c_char, c_void};
 
 #[no_mangle]
@@ -45,7 +46,7 @@ pub unsafe extern "C" fn keys_create(
         o_cb(
             user_data.0,
             FFI_RESULT_OK,
-            to_c_str(xorurl.to_string())?.as_ptr(),
+            CString::new(xorurl.to_string())?.as_ptr(),
             &bls_key_pair_into_repr_c(&keypair.as_ref().unwrap())?,
         );
         Ok(())
@@ -71,7 +72,7 @@ pub unsafe extern "C" fn keys_create_preload_test_coins(
         o_cb(
             user_data.0,
             FFI_RESULT_OK,
-            to_c_str(xorurl.to_string())?.as_ptr(),
+            CString::new(xorurl.to_string())?.as_ptr(),
             &bls_key_pair_into_repr_c(&keypair.as_ref().unwrap())?,
         );
         Ok(())
@@ -89,7 +90,7 @@ pub unsafe extern "C" fn keys_balance_from_sk(
         let user_data = OpaqueCtx(user_data);
         let secret_key = from_c_str(sk)?;
         let balance = (*app).keys_balance_from_sk(&secret_key)?;
-        let amount_result = to_c_str(balance)?;
+        let amount_result = CString::new(balance)?;
         o_cb(user_data.0, FFI_RESULT_OK, amount_result.as_ptr());
         Ok(())
     })
@@ -108,7 +109,7 @@ pub unsafe extern "C" fn keys_balance_from_url(
         let key_url = from_c_str(url)?;
         let secret_key = from_c_str(sk)?;
         let balance = (*app).keys_balance_from_url(&key_url, &secret_key)?;
-        let amount_result = to_c_str(balance)?;
+        let amount_result = CString::new(balance)?;
         o_cb(user_data.0, FFI_RESULT_OK, amount_result.as_ptr());
         Ok(())
     })
@@ -127,7 +128,7 @@ pub unsafe extern "C" fn validate_sk_for_url(
         let key_url = from_c_str(url)?;
         let secret_key = from_c_str(sk)?;
         let balance = (*app).validate_sk_for_url(&secret_key, &key_url)?;
-        let amount_result = to_c_str(balance)?;
+        let amount_result = CString::new(balance)?;
         o_cb(user_data.0, FFI_RESULT_OK, amount_result.as_ptr());
         Ok(())
     })

--- a/safe-ffi/ffi/nrs.rs
+++ b/safe-ffi/ffi/nrs.rs
@@ -2,9 +2,9 @@ use super::ffi_structs::{
     nrs_map_into_repr_c, processed_entries_into_repr_c, xorurl_encoder_into_repr_c, NrsMap,
     ProcessedEntries, XorUrlEncoder,
 };
-use super::helpers::to_c_str;
 use ffi_utils::{catch_unwind_cb, from_c_str, FfiResult, OpaqueCtx, FFI_RESULT_OK};
 use safe_api::{ResultReturn, Safe};
+use std::ffi::CString;
 use std::os::raw::{c_char, c_void};
 
 #[no_mangle]
@@ -82,7 +82,7 @@ pub unsafe extern "C" fn nrs_map_container_create(
         let link_str = from_c_str(link)?;
         let (nrs_map_container_xorurl, processed_entries, nrs_map) = (*app)
             .nrs_map_container_create(&nrs_str, &link_str, set_default, direct_link, dry_run)?;
-        let xorurl_string = to_c_str(nrs_map_container_xorurl)?;
+        let xorurl_string = CString::new(nrs_map_container_xorurl)?;
         let ffi_nrs_map = nrs_map_into_repr_c(&nrs_map)?;
         let ffi_processed_entries = processed_entries_into_repr_c(&processed_entries)?;
         o_cb(
@@ -124,7 +124,7 @@ pub unsafe extern "C" fn nrs_map_container_add(
             direct_link,
             dry_run,
         )?;
-        let xorurl_string = to_c_str(xorurl)?;
+        let xorurl_string = CString::new(xorurl)?;
         let ffi_nrs_map = nrs_map_into_repr_c(&nrs_map)?;
         o_cb(
             user_data.0,
@@ -156,7 +156,7 @@ pub unsafe extern "C" fn nrs_map_container_remove(
         let name_str = from_c_str(name)?;
         let (version, xorurl, _processed_entries, nrs_map) =
             (*app).nrs_map_container_remove(&name_str, dry_run)?;
-        let xorurl_string = to_c_str(xorurl)?;
+        let xorurl_string = CString::new(xorurl)?;
         let ffi_nrs_map = nrs_map_into_repr_c(&nrs_map)?;
         o_cb(
             user_data.0,

--- a/safe-ffi/ffi/wallet.rs
+++ b/safe-ffi/ffi/wallet.rs
@@ -2,9 +2,10 @@ use super::ffi_structs::{
     wallet_spendable_balance_into_repr_c, wallet_spendable_balances_into_repr_c,
     WalletSpendableBalance, WalletSpendableBalances,
 };
-use super::helpers::{from_c_str_to_str_option, to_c_str};
+use super::helpers::from_c_str_to_str_option;
 use ffi_utils::{catch_unwind_cb, from_c_str, FfiResult, OpaqueCtx, FFI_RESULT_OK};
 use safe_api::{ResultReturn, Safe};
+use std::ffi::CString;
 use std::os::raw::{c_char, c_void};
 
 #[no_mangle]
@@ -16,7 +17,7 @@ pub unsafe extern "C" fn wallet_create(
     catch_unwind_cb(user_data, o_cb, || -> ResultReturn<()> {
         let user_data = OpaqueCtx(user_data);
         let wallet_xorurl = (*app).wallet_create()?;
-        let wallet_xorurl_c_str = to_c_str(wallet_xorurl)?;
+        let wallet_xorurl_c_str = CString::new(wallet_xorurl)?;
         o_cb(user_data.0, FFI_RESULT_OK, wallet_xorurl_c_str.as_ptr());
         Ok(())
     })
@@ -39,7 +40,7 @@ pub unsafe extern "C" fn wallet_insert(
         let name_str = from_c_str_to_str_option(name);
         let wallet_name =
             (*app).wallet_insert(&key_url_str, name_str, set_default, &secret_key_str)?;
-        let wallet_name_c_str = to_c_str(wallet_name)?;
+        let wallet_name_c_str = CString::new(wallet_name)?;
         o_cb(user_data.0, FFI_RESULT_OK, wallet_name_c_str.as_ptr());
         Ok(())
     })
@@ -56,7 +57,7 @@ pub unsafe extern "C" fn wallet_balance(
         let user_data = OpaqueCtx(user_data);
         let wallet_url = from_c_str(url)?;
         let balance = (*app).wallet_balance(&wallet_url)?;
-        let amount_result = to_c_str(balance)?;
+        let amount_result = CString::new(balance)?;
         o_cb(user_data.0, FFI_RESULT_OK, amount_result.as_ptr());
         Ok(())
     })

--- a/safe-ffi/ffi/xorurl.rs
+++ b/safe-ffi/ffi/xorurl.rs
@@ -1,9 +1,10 @@
 use super::ffi_structs::{xorurl_encoder_into_repr_c, XorNameArray, XorUrlEncoder};
-use super::helpers::{from_c_str_to_str_option, to_c_str};
+use super::helpers::from_c_str_to_str_option;
 use ffi_utils::{catch_unwind_cb, from_c_str, FfiResult, OpaqueCtx, FFI_RESULT_OK};
 use safe_api::xorurl::{SafeContentType, SafeDataType, XorUrlEncoder as NativeXorUrlEncoder};
 use safe_api::ResultReturn;
 use safe_nd::XorName;
+use std::ffi::CString;
 use std::os::raw::{c_char, c_void};
 
 // todo: Can be convertered to a struct
@@ -41,7 +42,7 @@ pub unsafe extern "C" fn xorurl_encode(
             Some(content_version),
             &encoding_base,
         )?; //todo: update sub_names parameter
-        let encoded_string = to_c_str(encoded_xor_url)?;
+        let encoded_string = CString::new(encoded_xor_url)?;
         o_cb(user_data.0, FFI_RESULT_OK, encoded_string.as_ptr());
         Ok(())
     })


### PR DESCRIPTION
+ Remove `to_c_str`:

I was surprised to see this function because it's not something we use in FFI
elsewhere (like SCL). It's basically a wrapper around `CString::new` so as far
as I can tell it obscures the actual function call for no real benefit.

+ Remove panics from helpers

+ Remove `from_c_str_to_string_option`:

Where this is needed (which right now it's not), this can be replaced with `from_c_str(ptr).ok()`. As for `#[inline]`, I'm not sure if it's necessary: https://doc.rust-lang.org/reference/attributes/codegen.html#the-inline-attribute