### PR TITLE
chore(ci): remove running tests in docker build

### DIFF
--- a/resources/build-cache.sh
+++ b/resources/build-cache.sh
@@ -6,7 +6,7 @@ if [[ -z "$build_type" ]]; then
 fi
 
 if [[ "$build_type" == "dev" ]]; then
-    cargo test --release --features=mock-network,fake-auth -p safe-api -- --test-threads=1
+    cargo build --release --tests --features=mock-network,fake-auth
 else
     cargo build --release
 fi


### PR DESCRIPTION
These tests were failing during the Docker build job, but we don't really actually need to run the tests in this context.
