### PR TITLE
refactor/test: move unit tests to `tests` modules

### DIFF
--- a/safe-api/src/api/fake_scl.rs
+++ b/safe-api/src/api/fake_scl.rs
@@ -511,116 +511,119 @@ impl SafeApp for SafeAppFake {
     }
 }
 
-// Unit tests
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-#[test]
-fn test_allocate_test_coins() {
-    use self::SafeApp;
-    use std::str::FromStr;
-    use threshold_crypto::SecretKey;
-    use unwrap::unwrap;
+    #[test]
+    fn test_allocate_test_coins() {
+        use self::SafeApp;
+        use std::str::FromStr;
+        use threshold_crypto::SecretKey;
+        use unwrap::unwrap;
 
-    let mut mock = SafeAppFake::new();
+        let mut mock = SafeAppFake::new();
 
-    let sk_to = SecretKey::random();
+        let sk_to = SecretKey::random();
 
-    let balance = unwrap!(Coins::from_str("2.345678912"));
-    unwrap!(mock.allocate_test_coins(sk_to.clone(), balance));
-    let current_balance = unwrap!(mock.get_balance_from_sk(sk_to));
-    assert_eq!(balance, current_balance);
-}
+        let balance = unwrap!(Coins::from_str("2.345678912"));
+        unwrap!(mock.allocate_test_coins(sk_to.clone(), balance));
+        let current_balance = unwrap!(mock.get_balance_from_sk(sk_to));
+        assert_eq!(balance, current_balance);
+    }
 
-#[test]
-fn test_create_balance() {
-    use self::SafeApp;
-    use std::str::FromStr;
-    use threshold_crypto::SecretKey;
-    use unwrap::unwrap;
+    #[test]
+    fn test_create_balance() {
+        use self::SafeApp;
+        use std::str::FromStr;
+        use threshold_crypto::SecretKey;
+        use unwrap::unwrap;
 
-    let mut mock = SafeAppFake::new();
+        let mut mock = SafeAppFake::new();
 
-    let sk = SecretKey::random();
+        let sk = SecretKey::random();
 
-    let balance = unwrap!(Coins::from_str("2.345678912"));
-    unwrap!(mock.allocate_test_coins(sk.clone(), balance));
+        let balance = unwrap!(Coins::from_str("2.345678912"));
+        unwrap!(mock.allocate_test_coins(sk.clone(), balance));
 
-    let sk_to = SecretKey::random();
-    let pk_to = sk_to.public_key();
-    assert!(mock
-        .create_balance(Some(sk), pk_to, unwrap!(Coins::from_str("1.234567891")))
-        .is_ok());
-}
+        let sk_to = SecretKey::random();
+        let pk_to = sk_to.public_key();
+        assert!(mock
+            .create_balance(Some(sk), pk_to, unwrap!(Coins::from_str("1.234567891")))
+            .is_ok());
+    }
 
-#[test]
-fn test_check_balance() {
-    use self::SafeApp;
-    use std::str::FromStr;
-    use threshold_crypto::SecretKey;
-    use unwrap::unwrap;
+    #[test]
+    fn test_check_balance() {
+        use self::SafeApp;
+        use std::str::FromStr;
+        use threshold_crypto::SecretKey;
+        use unwrap::unwrap;
 
-    let mut mock = SafeAppFake::new();
+        let mut mock = SafeAppFake::new();
 
-    let sk = SecretKey::random();
+        let sk = SecretKey::random();
 
-    let balance = unwrap!(Coins::from_str("2.3"));
-    unwrap!(mock.allocate_test_coins(sk.clone(), balance));
-    let current_balance = unwrap!(mock.get_balance_from_sk(sk.clone()));
-    assert_eq!(balance, current_balance);
+        let balance = unwrap!(Coins::from_str("2.3"));
+        unwrap!(mock.allocate_test_coins(sk.clone(), balance));
+        let current_balance = unwrap!(mock.get_balance_from_sk(sk.clone()));
+        assert_eq!(balance, current_balance);
 
-    let sk_to = SecretKey::random();
-    let pk_to = sk_to.public_key();
-    let preload = unwrap!(Coins::from_str("1.234567891"));
-    unwrap!(mock.create_balance(Some(sk.clone()), pk_to, preload));
-    let current_balance = unwrap!(mock.get_balance_from_sk(sk_to));
-    assert_eq!(preload, current_balance);
+        let sk_to = SecretKey::random();
+        let pk_to = sk_to.public_key();
+        let preload = unwrap!(Coins::from_str("1.234567891"));
+        unwrap!(mock.create_balance(Some(sk.clone()), pk_to, preload));
+        let current_balance = unwrap!(mock.get_balance_from_sk(sk_to));
+        assert_eq!(preload, current_balance);
 
-    let current_balance = unwrap!(mock.get_balance_from_sk(sk));
-    assert_eq!(
-        unwrap!(Coins::from_str("1.065432108")), /* == 2.3 - 1.234567891 - 0.000000001 (creation cost) */
-        current_balance
-    );
-}
+        let current_balance = unwrap!(mock.get_balance_from_sk(sk));
+        assert_eq!(
+            unwrap!(Coins::from_str("1.065432108")), /* == 2.3 - 1.234567891 - 0.000000001 (creation cost) */
+            current_balance
+        );
+    }
 
-#[test]
-fn test_safecoin_transfer() {
-    use self::SafeApp;
-    use rand_core::RngCore;
-    use std::str::FromStr;
-    use threshold_crypto::SecretKey;
-    use unwrap::unwrap;
+    #[test]
+    fn test_safecoin_transfer() {
+        use self::SafeApp;
+        use rand_core::RngCore;
+        use std::str::FromStr;
+        use threshold_crypto::SecretKey;
+        use unwrap::unwrap;
 
-    let mut mock = SafeAppFake::new();
+        let mut mock = SafeAppFake::new();
 
-    let sk1 = SecretKey::random();
+        let sk1 = SecretKey::random();
 
-    let sk2 = SecretKey::random();
-    let pk2 = sk2.public_key();
+        let sk2 = SecretKey::random();
+        let pk2 = sk2.public_key();
 
-    let balance1 = unwrap!(Coins::from_str("2.5"));
-    let balance2 = unwrap!(Coins::from_str("5.7"));
-    unwrap!(mock.allocate_test_coins(sk1.clone(), balance1));
-    unwrap!(mock.allocate_test_coins(sk2.clone(), balance2));
+        let balance1 = unwrap!(Coins::from_str("2.5"));
+        let balance2 = unwrap!(Coins::from_str("5.7"));
+        unwrap!(mock.allocate_test_coins(sk1.clone(), balance1));
+        unwrap!(mock.allocate_test_coins(sk2.clone(), balance2));
 
-    let curr_balance1 = unwrap!(mock.get_balance_from_sk(sk1.clone()));
-    let curr_balance2 = unwrap!(mock.get_balance_from_sk(sk2.clone()));
+        let curr_balance1 = unwrap!(mock.get_balance_from_sk(sk1.clone()));
+        let curr_balance2 = unwrap!(mock.get_balance_from_sk(sk2.clone()));
 
-    assert_eq!(balance1, curr_balance1);
-    assert_eq!(balance2, curr_balance2);
+        assert_eq!(balance1, curr_balance1);
+        assert_eq!(balance2, curr_balance2);
 
-    let mut rng = rand::thread_rng();
-    let tx_id = rng.next_u64();
+        let mut rng = rand::thread_rng();
+        let tx_id = rng.next_u64();
 
-    let _ = unwrap!(mock.safecoin_transfer_to_xorname(
-        Some(sk1.clone()),
-        xorname_from_pk(pk2),
-        tx_id,
-        unwrap!(Coins::from_str("1.4"))
-    ));
-    unwrap!(mock.get_transaction(tx_id, pk2, sk2.clone()));
+        let _ = unwrap!(mock.safecoin_transfer_to_xorname(
+            Some(sk1.clone()),
+            xorname_from_pk(pk2),
+            tx_id,
+            unwrap!(Coins::from_str("1.4"))
+        ));
+        unwrap!(mock.get_transaction(tx_id, pk2, sk2.clone()));
 
-    let curr_balance1 = unwrap!(mock.get_balance_from_sk(sk1));
-    let curr_balance2 = unwrap!(mock.get_balance_from_sk(sk2));
+        let curr_balance1 = unwrap!(mock.get_balance_from_sk(sk1));
+        let curr_balance2 = unwrap!(mock.get_balance_from_sk(sk2));
 
-    assert_eq!(curr_balance1, unwrap!(Coins::from_str("1.1")));
-    assert_eq!(curr_balance2, unwrap!(Coins::from_str("7.1")));
+        assert_eq!(curr_balance1, unwrap!(Coins::from_str("1.1")));
+        assert_eq!(curr_balance2, unwrap!(Coins::from_str("7.1")));
+    }
 }

--- a/safe-api/src/api/fetch.rs
+++ b/safe-api/src/api/fetch.rs
@@ -326,11 +326,14 @@ fn embed_resolved_from(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::helpers::create_random_xorname;
+    use crate::api::xorurl::XorUrlEncoder;
+    use rand::distributions::Alphanumeric;
+    use rand::{thread_rng, Rng};
+    use unwrap::unwrap;
 
     #[test]
     fn test_fetch_key() {
-        use super::xorurl::XorUrlEncoder;
-        use unwrap::unwrap;
         let mut safe = Safe::new("base32z");
         unwrap!(safe.connect("", Some("fake-credentials")));
         let preload_amount = "1324.12";
@@ -350,8 +353,6 @@ mod tests {
 
     #[test]
     fn test_fetch_wallet() {
-        use super::xorurl::XorUrlEncoder;
-        use unwrap::unwrap;
         let mut safe = Safe::new("base32z");
         unwrap!(safe.connect("", Some("fake-credentials")));
         let xorurl = unwrap!(safe.wallet_create());
@@ -373,8 +374,6 @@ mod tests {
 
     #[test]
     fn test_fetch_files_container() {
-        use super::xorurl::XorUrlEncoder;
-        use unwrap::unwrap;
         let mut safe = Safe::new("base32z");
         unwrap!(safe.connect("", Some("fake-credentials")));
         safe.connect("", Some("")).unwrap();
@@ -414,11 +413,6 @@ mod tests {
 
     #[test]
     fn test_fetch_resolvable_container() {
-        use super::xorurl::XorUrlEncoder;
-        use rand::distributions::Alphanumeric;
-        use rand::{thread_rng, Rng};
-        use unwrap::unwrap;
-
         let site_name: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
 
         let mut safe = Safe::new("base32z");
@@ -463,11 +457,6 @@ mod tests {
 
     #[test]
     fn test_fetch_resolvable_map_data() {
-        use super::xorurl::XorUrlEncoder;
-        use rand::distributions::Alphanumeric;
-        use rand::{thread_rng, Rng};
-        use unwrap::unwrap;
-
         let site_name: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
 
         let mut safe = Safe::new("base32z");
@@ -512,8 +501,6 @@ mod tests {
 
     #[test]
     fn test_fetch_published_immutable_data() {
-        use super::xorurl::XorUrlEncoder;
-        use unwrap::unwrap;
         let mut safe = Safe::new("base32z");
         unwrap!(safe.connect("", Some("fake-credentials")));
         let data = b"Something super immutable";
@@ -537,9 +524,6 @@ mod tests {
 
     #[test]
     fn test_fetch_unsupported() {
-        use super::helpers::create_random_xorname;
-        use super::xorurl::XorUrlEncoder;
-        use unwrap::unwrap;
         let mut safe = Safe::new("base32z");
         unwrap!(safe.connect("", Some("fake-credentials")));
         let xorname = create_random_xorname();
@@ -567,9 +551,6 @@ mod tests {
 
     #[test]
     fn test_fetch_unsupported_with_media_type() {
-        use super::helpers::create_random_xorname;
-        use super::xorurl::XorUrlEncoder;
-        use unwrap::unwrap;
         let mut safe = Safe::new("base32z");
         unwrap!(safe.connect("", Some("fake-credentials")));
         let xorname = create_random_xorname();

--- a/safe-api/src/api/nrs.rs
+++ b/safe-api/src/api/nrs.rs
@@ -346,8 +346,8 @@ mod tests {
 
     #[test]
     fn test_nrs_map_container_create() {
-        use super::constants::FAKE_RDF_PREDICATE_LINK;
-        use super::nrs_map::DefaultRdf;
+        use crate::api::constants::FAKE_RDF_PREDICATE_LINK;
+        use crate::nrs_map::DefaultRdf;
         use rand::distributions::Alphanumeric;
         use rand::{thread_rng, Rng};
         use unwrap::unwrap;

--- a/safe-api/src/api/nrs.rs
+++ b/safe-api/src/api/nrs.rs
@@ -340,244 +340,247 @@ fn gen_nrs_map_raw_data(nrs_map: &NrsMap) -> ResultReturn<NrsMapRawData> {
     )])
 }
 
-// Unit Tests
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-#[test]
-fn test_nrs_map_container_create() {
-    use super::constants::FAKE_RDF_PREDICATE_LINK;
-    use super::nrs_map::DefaultRdf;
-    use rand::distributions::Alphanumeric;
-    use rand::{thread_rng, Rng};
-    use unwrap::unwrap;
+    #[test]
+    fn test_nrs_map_container_create() {
+        use super::constants::FAKE_RDF_PREDICATE_LINK;
+        use super::nrs_map::DefaultRdf;
+        use rand::distributions::Alphanumeric;
+        use rand::{thread_rng, Rng};
+        use unwrap::unwrap;
 
-    let site_name: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
+        let site_name: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
 
-    let mut safe = Safe::new("base32z");
-    safe.connect("", Some("fake-credentials")).unwrap();
+        let mut safe = Safe::new("base32z");
+        safe.connect("", Some("fake-credentials")).unwrap();
 
-    let nrs_xorname = xorname_from_nrs_string(&site_name).unwrap();
+        let nrs_xorname = xorname_from_nrs_string(&site_name).unwrap();
 
-    let (xor_url, _entries, nrs_map) = unwrap!(safe.nrs_map_container_create(
-        &site_name,
-        "safe://linked-from-<site_name>?v=0",
-        true,
-        false,
-        false
-    ));
-    assert_eq!(nrs_map.sub_names_map.len(), 0);
-    assert_eq!(
-        unwrap!(nrs_map.get_default_link()),
-        "safe://linked-from-<site_name>?v=0"
-    );
-
-    if let DefaultRdf::OtherRdf(def_data) = &nrs_map.default {
+        let (xor_url, _entries, nrs_map) = unwrap!(safe.nrs_map_container_create(
+            &site_name,
+            "safe://linked-from-<site_name>?v=0",
+            true,
+            false,
+            false
+        ));
+        assert_eq!(nrs_map.sub_names_map.len(), 0);
         assert_eq!(
-            *def_data.get(FAKE_RDF_PREDICATE_LINK).unwrap(),
-            "safe://linked-from-<site_name>?v=0".to_string()
+            unwrap!(nrs_map.get_default_link()),
+            "safe://linked-from-<site_name>?v=0"
         );
-        assert_eq!(
-            nrs_map.get_default().unwrap(),
-            &DefaultRdf::OtherRdf(def_data.clone())
-        );
-    } else {
-        panic!("No default definition map found...")
+
+        if let DefaultRdf::OtherRdf(def_data) = &nrs_map.default {
+            assert_eq!(
+                *def_data.get(FAKE_RDF_PREDICATE_LINK).unwrap(),
+                "safe://linked-from-<site_name>?v=0".to_string()
+            );
+            assert_eq!(
+                nrs_map.get_default().unwrap(),
+                &DefaultRdf::OtherRdf(def_data.clone())
+            );
+        } else {
+            panic!("No default definition map found...")
+        }
+
+        let decoder = XorUrlEncoder::from_url(&xor_url).unwrap();
+        assert_eq!(nrs_xorname, decoder.xorname())
     }
 
-    let decoder = XorUrlEncoder::from_url(&xor_url).unwrap();
-    assert_eq!(nrs_xorname, decoder.xorname())
-}
+    #[test]
+    fn test_nrs_map_container_add() {
+        use rand::distributions::Alphanumeric;
+        use rand::{thread_rng, Rng};
+        use unwrap::unwrap;
 
-#[test]
-fn test_nrs_map_container_add() {
-    use rand::distributions::Alphanumeric;
-    use rand::{thread_rng, Rng};
-    use unwrap::unwrap;
+        let site_name: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
 
-    let site_name: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
+        let mut safe = Safe::new("base32z");
+        safe.connect("", Some("fake-credentials")).unwrap();
 
-    let mut safe = Safe::new("base32z");
-    safe.connect("", Some("fake-credentials")).unwrap();
+        let (_xor_url, _entries, nrs_map) = unwrap!(safe.nrs_map_container_create(
+            &format!("b.{}", site_name),
+            "safe://linked-from-<b.site_name>?v=0",
+            true,
+            false,
+            false
+        ));
+        assert_eq!(nrs_map.sub_names_map.len(), 1);
+        assert_eq!(
+            unwrap!(nrs_map.get_default_link()),
+            "safe://linked-from-<b.site_name>?v=0"
+        );
 
-    let (_xor_url, _entries, nrs_map) = unwrap!(safe.nrs_map_container_create(
-        &format!("b.{}", site_name),
-        "safe://linked-from-<b.site_name>?v=0",
-        true,
-        false,
-        false
-    ));
-    assert_eq!(nrs_map.sub_names_map.len(), 1);
-    assert_eq!(
-        unwrap!(nrs_map.get_default_link()),
-        "safe://linked-from-<b.site_name>?v=0"
-    );
+        // add subname and set it as the new default too
+        let (version, _xorurl, _entries, updated_nrs_map) = unwrap!(safe.nrs_map_container_add(
+            &format!("a.b.{}", site_name),
+            "safe://linked-from-<a.b.site_name>?v=0",
+            true,
+            false,
+            false
+        ));
+        assert_eq!(version, 1);
+        assert_eq!(updated_nrs_map.sub_names_map.len(), 1);
+        assert_eq!(
+            unwrap!(updated_nrs_map.get_default_link()),
+            "safe://linked-from-<a.b.site_name>?v=0"
+        );
+    }
 
-    // add subname and set it as the new default too
-    let (version, _xorurl, _entries, updated_nrs_map) = unwrap!(safe.nrs_map_container_add(
-        &format!("a.b.{}", site_name),
-        "safe://linked-from-<a.b.site_name>?v=0",
-        true,
-        false,
-        false
-    ));
-    assert_eq!(version, 1);
-    assert_eq!(updated_nrs_map.sub_names_map.len(), 1);
-    assert_eq!(
-        unwrap!(updated_nrs_map.get_default_link()),
-        "safe://linked-from-<a.b.site_name>?v=0"
-    );
-}
+    #[test]
+    fn test_nrs_map_container_add_or_remove_with_versioned_target() {
+        use rand::distributions::Alphanumeric;
+        use rand::{thread_rng, Rng};
+        use unwrap::unwrap;
 
-#[test]
-fn test_nrs_map_container_add_or_remove_with_versioned_target() {
-    use rand::distributions::Alphanumeric;
-    use rand::{thread_rng, Rng};
-    use unwrap::unwrap;
+        let site_name: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
 
-    let site_name: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
+        let mut safe = Safe::new("base32z");
+        safe.connect("", Some("fake-credentials")).unwrap();
 
-    let mut safe = Safe::new("base32z");
-    safe.connect("", Some("fake-credentials")).unwrap();
+        let _ = unwrap!(safe.nrs_map_container_create(
+            &format!("b.{}", site_name),
+            "safe://linked-from-<b.site_name>?v=0",
+            true,
+            false,
+            false
+        ));
 
-    let _ = unwrap!(safe.nrs_map_container_create(
-        &format!("b.{}", site_name),
-        "safe://linked-from-<b.site_name>?v=0",
-        true,
-        false,
-        false
-    ));
+        let versioned_sitename = format!("safe://a.b.{}?v=6", site_name);
+        match safe.nrs_map_container_add(
+            &versioned_sitename,
+            "safe://linked-from-<a.b.site_name>?v=0",
+            true,
+            false,
+            false,
+        ) {
+            Ok(_) => panic!("Sync was unexpectdly successful"),
+            Err(err) => assert_eq!(
+                err,
+                Error::InvalidInput(format!(
+                    "The NRS name/subname URL cannot cannot contain a version: {}",
+                    versioned_sitename
+                ))
+            ),
+        };
 
-    let versioned_sitename = format!("safe://a.b.{}?v=6", site_name);
-    match safe.nrs_map_container_add(
-        &versioned_sitename,
-        "safe://linked-from-<a.b.site_name>?v=0",
-        true,
-        false,
-        false,
-    ) {
-        Ok(_) => panic!("Sync was unexpectdly successful"),
-        Err(err) => assert_eq!(
-            err,
-            Error::InvalidInput(format!(
-                "The NRS name/subname URL cannot cannot contain a version: {}",
-                versioned_sitename
-            ))
-        ),
-    };
+        match safe.nrs_map_container_remove(&versioned_sitename, false) {
+            Ok(_) => panic!("Sync was unexpectdly successful"),
+            Err(err) => assert_eq!(
+                err,
+                Error::InvalidInput(format!(
+                    "The NRS name/subname URL cannot cannot contain a version: {}",
+                    versioned_sitename
+                ))
+            ),
+        };
+    }
 
-    match safe.nrs_map_container_remove(&versioned_sitename, false) {
-        Ok(_) => panic!("Sync was unexpectdly successful"),
-        Err(err) => assert_eq!(
-            err,
-            Error::InvalidInput(format!(
-                "The NRS name/subname URL cannot cannot contain a version: {}",
-                versioned_sitename
-            ))
-        ),
-    };
-}
+    #[test]
+    fn test_nrs_map_container_remove_one_of_two() {
+        use rand::distributions::Alphanumeric;
+        use rand::{thread_rng, Rng};
+        use unwrap::unwrap;
 
-#[test]
-fn test_nrs_map_container_remove_one_of_two() {
-    use rand::distributions::Alphanumeric;
-    use rand::{thread_rng, Rng};
-    use unwrap::unwrap;
+        let site_name: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
 
-    let site_name: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
+        let mut safe = Safe::new("base32z");
+        safe.connect("", Some("fake-credentials")).unwrap();
 
-    let mut safe = Safe::new("base32z");
-    safe.connect("", Some("fake-credentials")).unwrap();
+        let (_xor_url, _entries, nrs_map) = unwrap!(safe.nrs_map_container_create(
+            &format!("a.b.{}", site_name),
+            "safe://linked-from-<a.b.site_name>?v=0",
+            true,
+            false,
+            false
+        ));
+        assert_eq!(nrs_map.sub_names_map.len(), 1);
 
-    let (_xor_url, _entries, nrs_map) = unwrap!(safe.nrs_map_container_create(
-        &format!("a.b.{}", site_name),
-        "safe://linked-from-<a.b.site_name>?v=0",
-        true,
-        false,
-        false
-    ));
-    assert_eq!(nrs_map.sub_names_map.len(), 1);
+        let (_version, _xorurl, _entries, _updated_nrs_map) = unwrap!(safe.nrs_map_container_add(
+            &format!("a2.b.{}", site_name),
+            "safe://linked-from-<a2.b.site_name>?v=0",
+            true,
+            false,
+            false
+        ));
 
-    let (_version, _xorurl, _entries, _updated_nrs_map) = unwrap!(safe.nrs_map_container_add(
-        &format!("a2.b.{}", site_name),
-        "safe://linked-from-<a2.b.site_name>?v=0",
-        true,
-        false,
-        false
-    ));
+        // remove subname
+        let (version, _xorurl, _entries, updated_nrs_map) =
+            unwrap!(safe.nrs_map_container_remove(&format!("a.b.{}", site_name), false));
+        assert_eq!(version, 2);
+        assert_eq!(updated_nrs_map.sub_names_map.len(), 1);
+        assert_eq!(
+            unwrap!(updated_nrs_map.get_default_link()),
+            "safe://linked-from-<a2.b.site_name>?v=0"
+        );
+    }
 
-    // remove subname
-    let (version, _xorurl, _entries, updated_nrs_map) =
-        unwrap!(safe.nrs_map_container_remove(&format!("a.b.{}", site_name), false));
-    assert_eq!(version, 2);
-    assert_eq!(updated_nrs_map.sub_names_map.len(), 1);
-    assert_eq!(
-        unwrap!(updated_nrs_map.get_default_link()),
-        "safe://linked-from-<a2.b.site_name>?v=0"
-    );
-}
+    #[test]
+    fn test_nrs_map_container_remove_default_soft_link() {
+        use rand::distributions::Alphanumeric;
+        use rand::{thread_rng, Rng};
+        use unwrap::unwrap;
 
-#[test]
-fn test_nrs_map_container_remove_default_soft_link() {
-    use rand::distributions::Alphanumeric;
-    use rand::{thread_rng, Rng};
-    use unwrap::unwrap;
+        let site_name: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
 
-    let site_name: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
+        let mut safe = Safe::new("base32z");
+        safe.connect("", Some("fake-credentials")).unwrap();
 
-    let mut safe = Safe::new("base32z");
-    safe.connect("", Some("fake-credentials")).unwrap();
+        let (_xor_url, _entries, nrs_map) = unwrap!(safe.nrs_map_container_create(
+            &format!("a.b.{}", site_name),
+            "safe://linked-from-<a.b.site_name>?v=0",
+            true,
+            false,
+            false
+        ));
+        assert_eq!(nrs_map.sub_names_map.len(), 1);
 
-    let (_xor_url, _entries, nrs_map) = unwrap!(safe.nrs_map_container_create(
-        &format!("a.b.{}", site_name),
-        "safe://linked-from-<a.b.site_name>?v=0",
-        true,
-        false,
-        false
-    ));
-    assert_eq!(nrs_map.sub_names_map.len(), 1);
+        // remove subname
+        let (version, _xorurl, _entries, updated_nrs_map) =
+            unwrap!(safe.nrs_map_container_remove(&format!("a.b.{}", site_name), false));
+        assert_eq!(version, 1);
+        assert_eq!(updated_nrs_map.sub_names_map.len(), 0);
+        match updated_nrs_map.get_default_link() {
+            Ok(_) => panic!("unexpectedly retrieved a default link"),
+            Err(Error::ContentError(msg)) => assert_eq!(
+                msg,
+                "Default found for resolvable map (set to sub names 'a.b') cannot be resolved."
+                    .to_string()
+            ),
+            Err(err) => panic!(format!("error returned is not the expected one: {}", err)),
+        };
+    }
 
-    // remove subname
-    let (version, _xorurl, _entries, updated_nrs_map) =
-        unwrap!(safe.nrs_map_container_remove(&format!("a.b.{}", site_name), false));
-    assert_eq!(version, 1);
-    assert_eq!(updated_nrs_map.sub_names_map.len(), 0);
-    match updated_nrs_map.get_default_link() {
-        Ok(_) => panic!("unexpectedly retrieved a default link"),
-        Err(Error::ContentError(msg)) => assert_eq!(
-            msg,
-            "Default found for resolvable map (set to sub names 'a.b') cannot be resolved."
-                .to_string()
-        ),
-        Err(err) => panic!(format!("error returned is not the expected one: {}", err)),
-    };
-}
+    #[test]
+    fn test_nrs_map_container_remove_default_hard_link() {
+        use rand::distributions::Alphanumeric;
+        use rand::{thread_rng, Rng};
+        use unwrap::unwrap;
 
-#[test]
-fn test_nrs_map_container_remove_default_hard_link() {
-    use rand::distributions::Alphanumeric;
-    use rand::{thread_rng, Rng};
-    use unwrap::unwrap;
+        let site_name: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
 
-    let site_name: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
+        let mut safe = Safe::new("base32z");
+        safe.connect("", Some("fake-credentials")).unwrap();
 
-    let mut safe = Safe::new("base32z");
-    safe.connect("", Some("fake-credentials")).unwrap();
+        let (_xor_url, _entries, nrs_map) = unwrap!(safe.nrs_map_container_create(
+            &format!("a.b.{}", site_name),
+            "safe://linked-from-<a.b.site_name>?v=0",
+            true,
+            true, // this sets the default to be a hard-link
+            false
+        ));
+        assert_eq!(nrs_map.sub_names_map.len(), 1);
 
-    let (_xor_url, _entries, nrs_map) = unwrap!(safe.nrs_map_container_create(
-        &format!("a.b.{}", site_name),
-        "safe://linked-from-<a.b.site_name>?v=0",
-        true,
-        true, // this sets the default to be a hard-link
-        false
-    ));
-    assert_eq!(nrs_map.sub_names_map.len(), 1);
-
-    // remove subname
-    let (version, _xorurl, _entries, updated_nrs_map) =
-        unwrap!(safe.nrs_map_container_remove(&format!("a.b.{}", site_name), false));
-    assert_eq!(version, 1);
-    assert_eq!(updated_nrs_map.sub_names_map.len(), 0);
-    assert_eq!(
-        unwrap!(updated_nrs_map.get_default_link()),
-        "safe://linked-from-<a.b.site_name>?v=0"
-    );
+        // remove subname
+        let (version, _xorurl, _entries, updated_nrs_map) =
+            unwrap!(safe.nrs_map_container_remove(&format!("a.b.{}", site_name), false));
+        assert_eq!(version, 1);
+        assert_eq!(updated_nrs_map.sub_names_map.len(), 0);
+        assert_eq!(
+            unwrap!(updated_nrs_map.get_default_link()),
+            "safe://linked-from-<a.b.site_name>?v=0"
+        );
+    }
 }

--- a/safe-api/src/api/safe_client_libs.rs
+++ b/safe-api/src/api/safe_client_libs.rs
@@ -603,10 +603,10 @@ fn get_public_bls_key(safe_app: &App) -> ResultReturn<PublicKey> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Safe;
 
     #[test]
     fn test_put_and_get_immutable_data() {
-        use super::Safe;
         let mut safe = Safe::new("base32z");
         safe.connect("", Some("fake-credentials")).unwrap();
 
@@ -623,7 +623,6 @@ mod tests {
 
     #[test]
     fn test_put_get_update_seq_append_only_data() {
-        use super::Safe;
         let mut safe = Safe::new("base32z");
         safe.connect("", Some("fake-credentials")).unwrap();
 
@@ -721,7 +720,6 @@ mod tests {
 
     #[test]
     fn test_update_seq_append_only_data_error() {
-        use super::Safe;
         let mut safe = Safe::new("base32z");
         safe.connect("", Some("fake-credentials")).unwrap();
 

--- a/safe-api/src/api/safe_client_libs.rs
+++ b/safe-api/src/api/safe_client_libs.rs
@@ -600,161 +600,164 @@ fn get_public_bls_key(safe_app: &App) -> ResultReturn<PublicKey> {
     })
 }
 
-// Unit tests
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-#[test]
-fn test_put_and_get_immutable_data() {
-    use super::Safe;
-    let mut safe = Safe::new("base32z");
-    safe.connect("", Some("fake-credentials")).unwrap();
+    #[test]
+    fn test_put_and_get_immutable_data() {
+        use super::Safe;
+        let mut safe = Safe::new("base32z");
+        safe.connect("", Some("fake-credentials")).unwrap();
 
-    let id1 = b"HELLLOOOOOOO".to_vec();
+        let id1 = b"HELLLOOOOOOO".to_vec();
 
-    let xorname = safe.safe_app.files_put_published_immutable(&id1).unwrap();
-    let data = safe
-        .safe_app
-        .files_get_published_immutable(xorname)
-        .unwrap();
-    let text = std::str::from_utf8(data.as_slice()).unwrap();
-    assert_eq!(text.to_string(), "HELLLOOOOOOO");
-}
-
-#[test]
-fn test_put_get_update_seq_append_only_data() {
-    use super::Safe;
-    let mut safe = Safe::new("base32z");
-    safe.connect("", Some("fake-credentials")).unwrap();
-
-    let key1 = b"KEY1".to_vec();
-    let val1 = b"VALUE1".to_vec();
-    let data1 = [(key1, val1)].to_vec();
-
-    let type_tag = 12322;
-    let xorname = safe
-        .safe_app
-        .put_seq_append_only_data(data1, None, type_tag, None)
-        .unwrap();
-
-    let (this_version, data) = safe
-        .safe_app
-        .get_latest_seq_append_only_data(xorname, type_tag)
-        .unwrap();
-
-    assert_eq!(this_version, 0);
-
-    //TODO: Properly unwrap data so this is clear (0 being version, 1 being data)
-    assert_eq!(std::str::from_utf8(data.0.as_slice()).unwrap(), "KEY1");
-    assert_eq!(std::str::from_utf8(data.1.as_slice()).unwrap(), "VALUE1");
-
-    let key2 = b"KEY2".to_vec();
-    let val2 = b"VALUE2".to_vec();
-    let data2 = [(key2, val2)].to_vec();
-    let new_version = 1;
-
-    let updated_version = safe
-        .safe_app
-        .append_seq_append_only_data(data2, new_version, xorname, type_tag)
-        .unwrap();
-    let (the_latest_version, data_updated) = safe
-        .safe_app
-        .get_latest_seq_append_only_data(xorname, type_tag)
-        .unwrap();
-
-    assert_eq!(updated_version, the_latest_version);
-
-    assert_eq!(
-        std::str::from_utf8(data_updated.0.as_slice()).unwrap(),
-        "KEY2"
-    );
-    assert_eq!(
-        std::str::from_utf8(data_updated.1.as_slice()).unwrap(),
-        "VALUE2"
-    );
-
-    let first_version = 0;
-
-    let first_data = safe
-        .safe_app
-        .get_seq_append_only_data(xorname, type_tag, first_version)
-        .unwrap();
-
-    assert_eq!(
-        std::str::from_utf8(first_data.0.as_slice()).unwrap(),
-        "KEY1"
-    );
-    assert_eq!(
-        std::str::from_utf8(first_data.1.as_slice()).unwrap(),
-        "VALUE1"
-    );
-
-    let second_version = 1;
-    let second_data = safe
-        .safe_app
-        .get_seq_append_only_data(xorname, type_tag, second_version)
-        .unwrap();
-
-    assert_eq!(
-        std::str::from_utf8(second_data.0.as_slice()).unwrap(),
-        "KEY2"
-    );
-    assert_eq!(
-        std::str::from_utf8(second_data.1.as_slice()).unwrap(),
-        "VALUE2"
-    );
-
-    // test checking for versions that dont exist
-    let nonexistant_version = 2;
-    match safe
-        .safe_app
-        .get_seq_append_only_data(xorname, type_tag, nonexistant_version)
-    {
-        Ok(_) => panic!("No error thrown when passing an outdated new version"),
-        Err(Error::VersionNotFound(msg)) => assert!(msg.contains(&format!(
-            "Invalid version ({}) for Sequenced AppendOnlyData found at XoR name {}",
-            nonexistant_version, xorname
-        ))),
-        err => panic!(format!("Error returned is not the expected one: {:?}", err)),
+        let xorname = safe.safe_app.files_put_published_immutable(&id1).unwrap();
+        let data = safe
+            .safe_app
+            .files_get_published_immutable(xorname)
+            .unwrap();
+        let text = std::str::from_utf8(data.as_slice()).unwrap();
+        assert_eq!(text.to_string(), "HELLLOOOOOOO");
     }
-}
 
-#[test]
-fn test_update_seq_append_only_data_error() {
-    use super::Safe;
-    let mut safe = Safe::new("base32z");
-    safe.connect("", Some("fake-credentials")).unwrap();
+    #[test]
+    fn test_put_get_update_seq_append_only_data() {
+        use super::Safe;
+        let mut safe = Safe::new("base32z");
+        safe.connect("", Some("fake-credentials")).unwrap();
 
-    let key1 = b"KEY1".to_vec();
-    let val1 = b"VALUE1".to_vec();
-    let data1 = [(key1, val1)].to_vec();
+        let key1 = b"KEY1".to_vec();
+        let val1 = b"VALUE1".to_vec();
+        let data1 = [(key1, val1)].to_vec();
 
-    let type_tag = 12322;
-    let xorname = safe
-        .safe_app
-        .put_seq_append_only_data(data1, None, type_tag, None)
-        .unwrap();
+        let type_tag = 12322;
+        let xorname = safe
+            .safe_app
+            .put_seq_append_only_data(data1, None, type_tag, None)
+            .unwrap();
 
-    let (this_version, data) = safe
-        .safe_app
-        .get_latest_seq_append_only_data(xorname, type_tag)
-        .unwrap();
+        let (this_version, data) = safe
+            .safe_app
+            .get_latest_seq_append_only_data(xorname, type_tag)
+            .unwrap();
 
-    assert_eq!(this_version, 0);
+        assert_eq!(this_version, 0);
 
-    //TODO: Properly unwrap data so this is clear (0 being version, 1 being data)
-    assert_eq!(std::str::from_utf8(data.0.as_slice()).unwrap(), "KEY1");
-    assert_eq!(std::str::from_utf8(data.1.as_slice()).unwrap(), "VALUE1");
+        //TODO: Properly unwrap data so this is clear (0 being version, 1 being data)
+        assert_eq!(std::str::from_utf8(data.0.as_slice()).unwrap(), "KEY1");
+        assert_eq!(std::str::from_utf8(data.1.as_slice()).unwrap(), "VALUE1");
 
-    let key2 = b"KEY2".to_vec();
-    let val2 = b"VALUE2".to_vec();
-    let data2 = [(key2, val2)].to_vec();
-    let wrong_new_version = 0;
+        let key2 = b"KEY2".to_vec();
+        let val2 = b"VALUE2".to_vec();
+        let data2 = [(key2, val2)].to_vec();
+        let new_version = 1;
 
-    match safe
-        .safe_app
-        .append_seq_append_only_data(data2, wrong_new_version, xorname, type_tag)
-    {
-        Ok(_) => panic!("No error thrown when passing an outdated new version"),
-        Err(Error::NetDataError(msg)) => assert!(msg.contains("Invalid data successor")),
-        _ => panic!("Error returned is not the expected one"),
+        let updated_version = safe
+            .safe_app
+            .append_seq_append_only_data(data2, new_version, xorname, type_tag)
+            .unwrap();
+        let (the_latest_version, data_updated) = safe
+            .safe_app
+            .get_latest_seq_append_only_data(xorname, type_tag)
+            .unwrap();
+
+        assert_eq!(updated_version, the_latest_version);
+
+        assert_eq!(
+            std::str::from_utf8(data_updated.0.as_slice()).unwrap(),
+            "KEY2"
+        );
+        assert_eq!(
+            std::str::from_utf8(data_updated.1.as_slice()).unwrap(),
+            "VALUE2"
+        );
+
+        let first_version = 0;
+
+        let first_data = safe
+            .safe_app
+            .get_seq_append_only_data(xorname, type_tag, first_version)
+            .unwrap();
+
+        assert_eq!(
+            std::str::from_utf8(first_data.0.as_slice()).unwrap(),
+            "KEY1"
+        );
+        assert_eq!(
+            std::str::from_utf8(first_data.1.as_slice()).unwrap(),
+            "VALUE1"
+        );
+
+        let second_version = 1;
+        let second_data = safe
+            .safe_app
+            .get_seq_append_only_data(xorname, type_tag, second_version)
+            .unwrap();
+
+        assert_eq!(
+            std::str::from_utf8(second_data.0.as_slice()).unwrap(),
+            "KEY2"
+        );
+        assert_eq!(
+            std::str::from_utf8(second_data.1.as_slice()).unwrap(),
+            "VALUE2"
+        );
+
+        // test checking for versions that dont exist
+        let nonexistant_version = 2;
+        match safe
+            .safe_app
+            .get_seq_append_only_data(xorname, type_tag, nonexistant_version)
+        {
+            Ok(_) => panic!("No error thrown when passing an outdated new version"),
+            Err(Error::VersionNotFound(msg)) => assert!(msg.contains(&format!(
+                "Invalid version ({}) for Sequenced AppendOnlyData found at XoR name {}",
+                nonexistant_version, xorname
+            ))),
+            err => panic!(format!("Error returned is not the expected one: {:?}", err)),
+        }
+    }
+
+    #[test]
+    fn test_update_seq_append_only_data_error() {
+        use super::Safe;
+        let mut safe = Safe::new("base32z");
+        safe.connect("", Some("fake-credentials")).unwrap();
+
+        let key1 = b"KEY1".to_vec();
+        let val1 = b"VALUE1".to_vec();
+        let data1 = [(key1, val1)].to_vec();
+
+        let type_tag = 12322;
+        let xorname = safe
+            .safe_app
+            .put_seq_append_only_data(data1, None, type_tag, None)
+            .unwrap();
+
+        let (this_version, data) = safe
+            .safe_app
+            .get_latest_seq_append_only_data(xorname, type_tag)
+            .unwrap();
+
+        assert_eq!(this_version, 0);
+
+        //TODO: Properly unwrap data so this is clear (0 being version, 1 being data)
+        assert_eq!(std::str::from_utf8(data.0.as_slice()).unwrap(), "KEY1");
+        assert_eq!(std::str::from_utf8(data.1.as_slice()).unwrap(), "VALUE1");
+
+        let key2 = b"KEY2".to_vec();
+        let val2 = b"VALUE2".to_vec();
+        let data2 = [(key2, val2)].to_vec();
+        let wrong_new_version = 0;
+
+        match safe
+            .safe_app
+            .append_seq_append_only_data(data2, wrong_new_version, xorname, type_tag)
+        {
+            Ok(_) => panic!("No error thrown when passing an outdated new version"),
+            Err(Error::NetDataError(msg)) => assert!(msg.contains("Invalid data successor")),
+            _ => panic!("Error returned is not the expected one"),
+        }
     }
 }

--- a/safe-api/src/api/wallet.rs
+++ b/safe-api/src/api/wallet.rs
@@ -487,650 +487,666 @@ fn resolve_wallet_url(
     Ok(wallet_balance)
 }
 
-// Unit Tests
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-#[test]
-fn test_wallet_create() {
-    use unwrap::unwrap;
-    let mut safe = Safe::new("base32z");
-    unwrap!(safe.connect("", Some("fake-credentials")));
-    let xorurl = unwrap!(safe.wallet_create());
-    assert!(xorurl.starts_with("safe://"));
+    #[test]
+    fn test_wallet_create() {
+        use unwrap::unwrap;
+        let mut safe = Safe::new("base32z");
+        unwrap!(safe.connect("", Some("fake-credentials")));
+        let xorurl = unwrap!(safe.wallet_create());
+        assert!(xorurl.starts_with("safe://"));
 
-    let current_balance = unwrap!(safe.wallet_balance(&xorurl));
-    assert_eq!("0.000000000", current_balance);
-}
+        let current_balance = unwrap!(safe.wallet_balance(&xorurl));
+        assert_eq!("0.000000000", current_balance);
+    }
 
-#[test]
-fn test_wallet_insert_and_balance() {
-    use unwrap::unwrap;
-    let mut safe = Safe::new("base32z");
-    unwrap!(safe.connect("", Some("fake-credentials")));
-    let wallet_xorurl = unwrap!(safe.wallet_create());
-    let (_key1_xorurl, key_pair1) = unwrap!(safe.keys_create_preload_test_coins("12.23"));
-    let (_key2_xorurl, key_pair2) = unwrap!(safe.keys_create_preload_test_coins("1.53"));
+    #[test]
+    fn test_wallet_insert_and_balance() {
+        use unwrap::unwrap;
+        let mut safe = Safe::new("base32z");
+        unwrap!(safe.connect("", Some("fake-credentials")));
+        let wallet_xorurl = unwrap!(safe.wallet_create());
+        let (_key1_xorurl, key_pair1) = unwrap!(safe.keys_create_preload_test_coins("12.23"));
+        let (_key2_xorurl, key_pair2) = unwrap!(safe.keys_create_preload_test_coins("1.53"));
 
-    unwrap!(safe.wallet_insert(
-        &wallet_xorurl,
-        Some("my-first-balance"),
-        true,
-        &unwrap!(key_pair1).sk,
-    ));
+        unwrap!(safe.wallet_insert(
+            &wallet_xorurl,
+            Some("my-first-balance"),
+            true,
+            &unwrap!(key_pair1).sk,
+        ));
 
-    let current_balance = unwrap!(safe.wallet_balance(&wallet_xorurl));
-    assert_eq!("12.230000000", current_balance);
+        let current_balance = unwrap!(safe.wallet_balance(&wallet_xorurl));
+        assert_eq!("12.230000000", current_balance);
 
-    unwrap!(safe.wallet_insert(
-        &wallet_xorurl,
-        Some("my-second-balance"),
-        false,
-        &unwrap!(key_pair2).sk,
-    ));
+        unwrap!(safe.wallet_insert(
+            &wallet_xorurl,
+            Some("my-second-balance"),
+            false,
+            &unwrap!(key_pair2).sk,
+        ));
 
-    let current_balance = unwrap!(safe.wallet_balance(&wallet_xorurl));
-    assert_eq!("13.760000000" /*== 12.23 + 1.53*/, current_balance);
-}
+        let current_balance = unwrap!(safe.wallet_balance(&wallet_xorurl));
+        assert_eq!("13.760000000" /*== 12.23 + 1.53*/, current_balance);
+    }
 
-#[test]
-fn test_wallet_insert_and_get() {
-    use unwrap::unwrap;
-    let mut safe = Safe::new("base32z");
-    unwrap!(safe.connect("", Some("fake-credentials")));
-    let wallet_xorurl = unwrap!(safe.wallet_create());
-    let (key1_xorurl, key_pair1) = unwrap!(safe.keys_create_preload_test_coins("12.23"));
-    let (key2_xorurl, key_pair2) = unwrap!(safe.keys_create_preload_test_coins("1.53"));
+    #[test]
+    fn test_wallet_insert_and_get() {
+        use unwrap::unwrap;
+        let mut safe = Safe::new("base32z");
+        unwrap!(safe.connect("", Some("fake-credentials")));
+        let wallet_xorurl = unwrap!(safe.wallet_create());
+        let (key1_xorurl, key_pair1) = unwrap!(safe.keys_create_preload_test_coins("12.23"));
+        let (key2_xorurl, key_pair2) = unwrap!(safe.keys_create_preload_test_coins("1.53"));
 
-    unwrap!(safe.wallet_insert(
-        &wallet_xorurl,
-        Some("my-first-balance"),
-        true,
-        &unwrap!(key_pair1.clone()).sk,
-    ));
+        unwrap!(safe.wallet_insert(
+            &wallet_xorurl,
+            Some("my-first-balance"),
+            true,
+            &unwrap!(key_pair1.clone()).sk,
+        ));
 
-    unwrap!(safe.wallet_insert(
-        &wallet_xorurl,
-        Some("my-second-balance"),
-        false,
-        &unwrap!(key_pair2.clone()).sk,
-    ));
+        unwrap!(safe.wallet_insert(
+            &wallet_xorurl,
+            Some("my-second-balance"),
+            false,
+            &unwrap!(key_pair2.clone()).sk,
+        ));
 
-    let wallet_balances = unwrap!(safe.wallet_get(&wallet_xorurl));
-    assert_eq!(wallet_balances["my-first-balance"].0, true);
-    assert_eq!(wallet_balances["my-first-balance"].1.xorurl, key1_xorurl);
-    assert_eq!(
-        wallet_balances["my-first-balance"].1.sk,
-        unwrap!(key_pair1).sk
-    );
+        let wallet_balances = unwrap!(safe.wallet_get(&wallet_xorurl));
+        assert_eq!(wallet_balances["my-first-balance"].0, true);
+        assert_eq!(wallet_balances["my-first-balance"].1.xorurl, key1_xorurl);
+        assert_eq!(
+            wallet_balances["my-first-balance"].1.sk,
+            unwrap!(key_pair1).sk
+        );
 
-    assert_eq!(wallet_balances["my-second-balance"].0, false);
-    assert_eq!(wallet_balances["my-second-balance"].1.xorurl, key2_xorurl);
-    assert_eq!(
-        wallet_balances["my-second-balance"].1.sk,
-        unwrap!(key_pair2).sk
-    );
-}
+        assert_eq!(wallet_balances["my-second-balance"].0, false);
+        assert_eq!(wallet_balances["my-second-balance"].1.xorurl, key2_xorurl);
+        assert_eq!(
+            wallet_balances["my-second-balance"].1.sk,
+            unwrap!(key_pair2).sk
+        );
+    }
 
-#[test]
-fn test_wallet_insert_and_set_default() {
-    use unwrap::unwrap;
-    let mut safe = Safe::new("base32z");
-    unwrap!(safe.connect("", Some("fake-credentials")));
-    let wallet_xorurl = unwrap!(safe.wallet_create());
-    let (key1_xorurl, key_pair1) = unwrap!(safe.keys_create_preload_test_coins("65.82"));
-    let (key2_xorurl, key_pair2) = unwrap!(safe.keys_create_preload_test_coins("11.44"));
+    #[test]
+    fn test_wallet_insert_and_set_default() {
+        use unwrap::unwrap;
+        let mut safe = Safe::new("base32z");
+        unwrap!(safe.connect("", Some("fake-credentials")));
+        let wallet_xorurl = unwrap!(safe.wallet_create());
+        let (key1_xorurl, key_pair1) = unwrap!(safe.keys_create_preload_test_coins("65.82"));
+        let (key2_xorurl, key_pair2) = unwrap!(safe.keys_create_preload_test_coins("11.44"));
 
-    unwrap!(safe.wallet_insert(
-        &wallet_xorurl,
-        Some("my-first-balance"),
-        true,
-        &unwrap!(key_pair1.clone()).sk,
-    ));
+        unwrap!(safe.wallet_insert(
+            &wallet_xorurl,
+            Some("my-first-balance"),
+            true,
+            &unwrap!(key_pair1.clone()).sk,
+        ));
 
-    unwrap!(safe.wallet_insert(
-        &wallet_xorurl,
-        Some("my-second-balance"),
-        true,
-        &unwrap!(key_pair2.clone()).sk,
-    ));
+        unwrap!(safe.wallet_insert(
+            &wallet_xorurl,
+            Some("my-second-balance"),
+            true,
+            &unwrap!(key_pair2.clone()).sk,
+        ));
 
-    let wallet_balances = unwrap!(safe.wallet_get(&wallet_xorurl));
-    assert_eq!(wallet_balances["my-first-balance"].0, false);
-    assert_eq!(wallet_balances["my-first-balance"].1.xorurl, key1_xorurl);
-    assert_eq!(
-        wallet_balances["my-first-balance"].1.sk,
-        unwrap!(key_pair1).sk
-    );
+        let wallet_balances = unwrap!(safe.wallet_get(&wallet_xorurl));
+        assert_eq!(wallet_balances["my-first-balance"].0, false);
+        assert_eq!(wallet_balances["my-first-balance"].1.xorurl, key1_xorurl);
+        assert_eq!(
+            wallet_balances["my-first-balance"].1.sk,
+            unwrap!(key_pair1).sk
+        );
 
-    assert_eq!(wallet_balances["my-second-balance"].0, true);
-    assert_eq!(wallet_balances["my-second-balance"].1.xorurl, key2_xorurl);
-    assert_eq!(
-        wallet_balances["my-second-balance"].1.sk,
-        unwrap!(key_pair2).sk
-    );
-}
+        assert_eq!(wallet_balances["my-second-balance"].0, true);
+        assert_eq!(wallet_balances["my-second-balance"].1.xorurl, key2_xorurl);
+        assert_eq!(
+            wallet_balances["my-second-balance"].1.sk,
+            unwrap!(key_pair2).sk
+        );
+    }
 
-#[test]
-fn test_wallet_transfer_no_default() {
-    use unwrap::unwrap;
-    let mut safe = Safe::new("base32z");
-    unwrap!(safe.connect("", Some("fake-credentials")));
-    let from_wallet_xorurl = unwrap!(safe.wallet_create()); // this one won't have a default balance
+    #[test]
+    fn test_wallet_transfer_no_default() {
+        use unwrap::unwrap;
+        let mut safe = Safe::new("base32z");
+        unwrap!(safe.connect("", Some("fake-credentials")));
+        let from_wallet_xorurl = unwrap!(safe.wallet_create()); // this one won't have a default balance
 
-    let to_wallet_xorurl = unwrap!(safe.wallet_create()); // we'll insert a default balance
-    let (_key_xorurl, key_pair) = unwrap!(safe.keys_create_preload_test_coins("43523"));
-    unwrap!(safe.wallet_insert(
-        &to_wallet_xorurl,
-        Some("my-first-balance"),
-        true, // set --default
-        &unwrap!(key_pair).sk,
-    ));
+        let to_wallet_xorurl = unwrap!(safe.wallet_create()); // we'll insert a default balance
+        let (_key_xorurl, key_pair) = unwrap!(safe.keys_create_preload_test_coins("43523"));
+        unwrap!(safe.wallet_insert(
+            &to_wallet_xorurl,
+            Some("my-first-balance"),
+            true, // set --default
+            &unwrap!(key_pair).sk,
+        ));
 
-    // test no default balance at wallet in <from> argument
-    match safe.wallet_transfer("10", Some(&from_wallet_xorurl), &to_wallet_xorurl, None) {
-        Err(Error::ContentError(msg)) => assert_eq!(
-            msg,
-            format!(
-                "No default balance found at Wallet \"{}\"",
-                from_wallet_xorurl
-            )
-        ),
-        Err(err) => panic!(format!("Error returned is not the expected: {:?}", err)),
-        Ok(_) => panic!("Transfer succeeded unexpectedly"),
-    };
-
-    // invert wallets and test no default balance at wallet in <to> argument
-    match safe.wallet_transfer("10", Some(&to_wallet_xorurl), &from_wallet_xorurl, None) {
-        Err(Error::ContentError(msg)) => assert_eq!(
-            msg,
-            format!(
-                "No default balance found at Wallet \"{}\"",
-                from_wallet_xorurl
-            )
-        ),
-        Err(err) => panic!(format!("Error returned is not the expected: {:?}", err)),
-        Ok(_) => panic!("Transfer succeeded unexpectedly"),
-    };
-}
-
-#[test]
-fn test_wallet_transfer_from_zero_balance() {
-    use unwrap::unwrap;
-    let mut safe = Safe::new("base32z");
-    unwrap!(safe.connect("", Some("fake-credentials")));
-    let from_wallet_xorurl = unwrap!(safe.wallet_create());
-    let (_key_xorurl1, key_pair1) = unwrap!(safe.keys_create_preload_test_coins("0.0"));
-    unwrap!(safe.wallet_insert(
-        &from_wallet_xorurl,
-        Some("my-first-balance"),
-        true, // set --default
-        &unwrap!(key_pair1).sk,
-    ));
-
-    let (to_key_xorurl, _key_pair2) = unwrap!(safe.keys_create_preload_test_coins("0.5"));
-
-    // test fail to transfer with 0 balance at wallet in <from> argument
-    match safe.wallet_transfer("0", Some(&from_wallet_xorurl), &to_key_xorurl, None) {
-        Err(Error::InvalidAmount(msg)) => assert_eq!(
-            msg,
-            "The amount '0' specified for the transfer is invalid".to_string()
-        ),
-        Err(err) => panic!(format!("Error returned is not the expected: {:?}", err)),
-        Ok(_) => panic!("Transfer succeeded unexpectedly"),
-    };
-
-    let to_wallet_xorurl = unwrap!(safe.wallet_create());
-    let (_key_xorurl2, key_pair2) = unwrap!(safe.keys_create_preload_test_coins("0.5"));
-    unwrap!(safe.wallet_insert(
-        &to_wallet_xorurl,
-        Some("also-my-balance"),
-        true, // set --default
-        &unwrap!(key_pair2).sk,
-    ));
-
-    // test fail to transfer with 0 balance at wallet in <from> argument
-    match safe.wallet_transfer("0", Some(&from_wallet_xorurl), &to_wallet_xorurl, None) {
-        Err(Error::InvalidAmount(msg)) => assert_eq!(
-            msg,
-            "The amount '0' specified for the transfer is invalid".to_string()
-        ),
-        Err(err) => panic!(format!("Error returned is not the expected: {:?}", err)),
-        Ok(_) => panic!("Transfer succeeded unexpectedly"),
-    };
-}
-
-#[test]
-fn test_wallet_transfer_diff_amounts() {
-    use unwrap::unwrap;
-    let mut safe = Safe::new("base32z");
-    unwrap!(safe.connect("", Some("fake-credentials")));
-    let from_wallet_xorurl = unwrap!(safe.wallet_create());
-    let (_key_xorurl1, key_pair1) = unwrap!(safe.keys_create_preload_test_coins("100.5"));
-    unwrap!(safe.wallet_insert(
-        &from_wallet_xorurl,
-        Some("my-first-balance"),
-        true, // set --default
-        &unwrap!(key_pair1.clone()).sk,
-    ));
-
-    let to_wallet_xorurl = unwrap!(safe.wallet_create());
-    let (_key_xorurl2, key_pair2) = unwrap!(safe.keys_create_preload_test_coins("0.5"));
-    unwrap!(safe.wallet_insert(
-        &to_wallet_xorurl,
-        Some("also-my-balance"),
-        true, // set --default
-        &unwrap!(key_pair2.clone()).sk,
-    ));
-
-    // test fail to transfer more than current balance at wallet in <from> argument
-    match safe.wallet_transfer("100.6", Some(&from_wallet_xorurl), &to_wallet_xorurl, None) {
-        Err(Error::NotEnoughBalance(msg)) => assert_eq!(
-            msg,
-            format!(
-                "Not enough balance for the transfer at Wallet \"{}\"",
-                from_wallet_xorurl
-            )
-        ),
-        Err(err) => panic!(format!("Error returned is not the expected: {:?}", err)),
-        Ok(_) => panic!("Transfer succeeded unexpectedly"),
-    };
-
-    // test fail to transfer as it's a invalid/non-numeric amount
-    match safe.wallet_transfer(".06", Some(&from_wallet_xorurl), &to_wallet_xorurl, None) {
-        Err(Error::InvalidAmount(msg)) => assert_eq!(
-            msg,
-            "Invalid safecoins amount '.06' (Can\'t parse coin units)"
-        ),
-        Err(err) => panic!(format!("Error returned is not the expected: {:?}", err)),
-        Ok(_) => panic!("Transfer succeeded unexpectedly"),
-    };
-
-    // test successful transfer
-    match safe.wallet_transfer("100.4", Some(&from_wallet_xorurl), &to_wallet_xorurl, None) {
-        Err(msg) => panic!(format!("Transfer was expected to succeed: {}", msg)),
-        Ok(_) => {
-            let from_current_balance = unwrap!(safe.wallet_balance(&from_wallet_xorurl));
-            assert_eq!("0.100000000", from_current_balance);
-            let to_current_balance = unwrap!(safe.wallet_balance(&to_wallet_xorurl));
-            assert_eq!("100.900000000", to_current_balance);
-        }
-    };
-}
-
-#[test]
-fn test_wallet_transfer_to_safekey() {
-    use unwrap::unwrap;
-    let mut safe = Safe::new("base32z");
-    unwrap!(safe.connect("", Some("fake-credentials")));
-
-    let from_wallet_xorurl = unwrap!(safe.wallet_create());
-    let (_, key_pair1) = unwrap!(safe.keys_create_preload_test_coins("4621.45"));
-    unwrap!(safe.wallet_insert(
-        &from_wallet_xorurl,
-        Some("my-first-balance"),
-        true, // set --default
-        &unwrap!(key_pair1.clone()).sk,
-    ));
-
-    let (key_xorurl, key_pair2) = unwrap!(safe.keys_create_preload_test_coins("10.0"));
-
-    // test successful transfer
-    match safe.wallet_transfer("523.87", Some(&from_wallet_xorurl), &key_xorurl, None) {
-        Err(msg) => panic!(format!("Transfer was expected to succeed: {}", msg)),
-        Ok(_) => {
-            let from_current_balance = unwrap!(safe.wallet_balance(&from_wallet_xorurl));
-            assert_eq!(
-                "4097.580000000", /* 4621.45 - 523.87 */
-                from_current_balance
-            );
-            let key_current_balance = unwrap!(safe.keys_balance_from_sk(&unwrap!(key_pair2).sk));
-            assert_eq!("533.870000000", key_current_balance);
-        }
-    };
-}
-
-#[test]
-fn test_wallet_transfer_from_safekey() {
-    use unwrap::unwrap;
-    let mut safe = Safe::new("base32z");
-    unwrap!(safe.connect("", Some("fake-credentials")));
-
-    let (safekey_xorurl1, _) = unwrap!(safe.keys_create_preload_test_coins("7"));
-    let (safekey_xorurl2, _) = unwrap!(safe.keys_create_preload_test_coins("0"));
-
-    match safe.wallet_transfer("1", Some(&safekey_xorurl1), &safekey_xorurl2, None) {
-        Ok(_) => panic!("Transfer from SafeKey was expected to fail".to_string()),
-        Err(Error::InvalidInput(msg)) => {
-            assert_eq!(
+        // test no default balance at wallet in <from> argument
+        match safe.wallet_transfer("10", Some(&from_wallet_xorurl), &to_wallet_xorurl, None) {
+            Err(Error::ContentError(msg)) => assert_eq!(
                 msg,
-                "The 'from_url' URL doesn't target a Wallet, it is: Raw (SafeKey)"
-            );
-        }
-        Err(err) => panic!(format!("Error is not the expected one: {:?}", err)),
-    };
-}
+                format!(
+                    "No default balance found at Wallet \"{}\"",
+                    from_wallet_xorurl
+                )
+            ),
+            Err(err) => panic!(format!("Error returned is not the expected: {:?}", err)),
+            Ok(_) => panic!("Transfer succeeded unexpectedly"),
+        };
 
-#[test]
-fn test_wallet_transfer_with_nrs_urls() {
-    use rand::distributions::Alphanumeric;
-    use rand::{thread_rng, Rng};
-    use unwrap::unwrap;
-    let mut safe = Safe::new("base32z");
-    unwrap!(safe.connect("", Some("fake-credentials")));
+        // invert wallets and test no default balance at wallet in <to> argument
+        match safe.wallet_transfer("10", Some(&to_wallet_xorurl), &from_wallet_xorurl, None) {
+            Err(Error::ContentError(msg)) => assert_eq!(
+                msg,
+                format!(
+                    "No default balance found at Wallet \"{}\"",
+                    from_wallet_xorurl
+                )
+            ),
+            Err(err) => panic!(format!("Error returned is not the expected: {:?}", err)),
+            Ok(_) => panic!("Transfer succeeded unexpectedly"),
+        };
+    }
 
-    let from_wallet_xorurl = unwrap!(safe.wallet_create());
-    let (_, key_pair1) = unwrap!(safe.keys_create_preload_test_coins("0.2"));
-    unwrap!(safe.wallet_insert(
-        &from_wallet_xorurl,
-        Some("my-first-balance"),
-        true, // set --default
-        &unwrap!(key_pair1.clone()).sk,
-    ));
+    #[test]
+    fn test_wallet_transfer_from_zero_balance() {
+        use unwrap::unwrap;
+        let mut safe = Safe::new("base32z");
+        unwrap!(safe.connect("", Some("fake-credentials")));
+        let from_wallet_xorurl = unwrap!(safe.wallet_create());
+        let (_key_xorurl1, key_pair1) = unwrap!(safe.keys_create_preload_test_coins("0.0"));
+        unwrap!(safe.wallet_insert(
+            &from_wallet_xorurl,
+            Some("my-first-balance"),
+            true, // set --default
+            &unwrap!(key_pair1).sk,
+        ));
 
-    let from_nrsurl: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
-    let _ = unwrap!(safe.nrs_map_container_create(
-        &from_nrsurl,
-        &from_wallet_xorurl,
-        false,
-        true,
-        false
-    ));
+        let (to_key_xorurl, _key_pair2) = unwrap!(safe.keys_create_preload_test_coins("0.5"));
 
-    let (key_xorurl, key_pair2) = unwrap!(safe.keys_create_preload_test_coins("0.1"));
-    let to_nrsurl: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
-    let _ = unwrap!(safe.nrs_map_container_create(&to_nrsurl, &key_xorurl, false, true, false));
+        // test fail to transfer with 0 balance at wallet in <from> argument
+        match safe.wallet_transfer("0", Some(&from_wallet_xorurl), &to_key_xorurl, None) {
+            Err(Error::InvalidAmount(msg)) => assert_eq!(
+                msg,
+                "The amount '0' specified for the transfer is invalid".to_string()
+            ),
+            Err(err) => panic!(format!("Error returned is not the expected: {:?}", err)),
+            Ok(_) => panic!("Transfer succeeded unexpectedly"),
+        };
 
-    // test successful transfer
-    match safe.wallet_transfer("0.2", Some(&from_nrsurl), &to_nrsurl, None) {
-        Err(msg) => panic!(format!("Transfer was expected to succeed: {}", msg)),
-        Ok(_) => {
-            let from_current_balance = unwrap!(safe.wallet_balance(&from_nrsurl));
-            assert_eq!("0.000000000" /* 0.2 - 0.2 */, from_current_balance);
-            let key_current_balance = unwrap!(safe.keys_balance_from_sk(&unwrap!(key_pair2).sk));
-            assert_eq!("0.300000000" /* 0.1 + 0.2 */, key_current_balance);
-        }
-    };
-}
+        let to_wallet_xorurl = unwrap!(safe.wallet_create());
+        let (_key_xorurl2, key_pair2) = unwrap!(safe.keys_create_preload_test_coins("0.5"));
+        unwrap!(safe.wallet_insert(
+            &to_wallet_xorurl,
+            Some("also-my-balance"),
+            true, // set --default
+            &unwrap!(key_pair2).sk,
+        ));
 
-#[test]
-fn test_wallet_transfer_from_specific_balance() {
-    use unwrap::unwrap;
-    let mut safe = Safe::new("base32z");
-    unwrap!(safe.connect("", Some("fake-credentials")));
-    let from_wallet_xorurl = unwrap!(safe.wallet_create());
-    let (_key_xorurl1, key_pair1) = unwrap!(safe.keys_create_preload_test_coins("100.5"));
-    unwrap!(safe.wallet_insert(
-        &from_wallet_xorurl,
-        Some("from-first-balance"),
-        true, // set --default
-        &unwrap!(key_pair1.clone()).sk,
-    ));
+        // test fail to transfer with 0 balance at wallet in <from> argument
+        match safe.wallet_transfer("0", Some(&from_wallet_xorurl), &to_wallet_xorurl, None) {
+            Err(Error::InvalidAmount(msg)) => assert_eq!(
+                msg,
+                "The amount '0' specified for the transfer is invalid".to_string()
+            ),
+            Err(err) => panic!(format!("Error returned is not the expected: {:?}", err)),
+            Ok(_) => panic!("Transfer succeeded unexpectedly"),
+        };
+    }
 
-    let (_key_xorurl2, key_pair2) = unwrap!(safe.keys_create_preload_test_coins("200.5"));
-    unwrap!(safe.wallet_insert(
-        &from_wallet_xorurl,
-        Some("from-second-balance"),
-        false,
-        &unwrap!(key_pair2.clone()).sk,
-    ));
+    #[test]
+    fn test_wallet_transfer_diff_amounts() {
+        use unwrap::unwrap;
+        let mut safe = Safe::new("base32z");
+        unwrap!(safe.connect("", Some("fake-credentials")));
+        let from_wallet_xorurl = unwrap!(safe.wallet_create());
+        let (_key_xorurl1, key_pair1) = unwrap!(safe.keys_create_preload_test_coins("100.5"));
+        unwrap!(safe.wallet_insert(
+            &from_wallet_xorurl,
+            Some("my-first-balance"),
+            true, // set --default
+            &unwrap!(key_pair1.clone()).sk,
+        ));
 
-    let to_wallet_xorurl = unwrap!(safe.wallet_create());
-    let (_key_xorurl3, key_pair3) = unwrap!(safe.keys_create_preload_test_coins("10.5"));
-    unwrap!(safe.wallet_insert(
-        &to_wallet_xorurl,
-        Some("to-first-balance"),
-        true, // set --default
-        &unwrap!(key_pair3.clone()).sk,
-    ));
+        let to_wallet_xorurl = unwrap!(safe.wallet_create());
+        let (_key_xorurl2, key_pair2) = unwrap!(safe.keys_create_preload_test_coins("0.5"));
+        unwrap!(safe.wallet_insert(
+            &to_wallet_xorurl,
+            Some("also-my-balance"),
+            true, // set --default
+            &unwrap!(key_pair2.clone()).sk,
+        ));
 
-    // test fail to transfer more than current balance at 'from-firstbaance'
-    let mut from_wallet_spendable_balance = unwrap!(XorUrlEncoder::from_url(&from_wallet_xorurl));
-    from_wallet_spendable_balance.set_path("from-second-balance");
-    let from_spendable_balance = unwrap!(from_wallet_spendable_balance.to_string());
-    match safe.wallet_transfer(
-        "200.6",
-        Some(&from_spendable_balance),
-        &to_wallet_xorurl,
-        None,
-    ) {
-        Err(Error::NotEnoughBalance(msg)) => assert_eq!(
-            msg,
-            format!(
-                "Not enough balance for the transfer at Wallet \"{}\"",
-                from_spendable_balance
-            )
-        ),
-        Err(err) => panic!(format!("Error returned is not the expected: {:?}", err)),
-        Ok(_) => panic!("Transfer succeeded unexpectedly"),
-    };
+        // test fail to transfer more than current balance at wallet in <from> argument
+        match safe.wallet_transfer("100.6", Some(&from_wallet_xorurl), &to_wallet_xorurl, None) {
+            Err(Error::NotEnoughBalance(msg)) => assert_eq!(
+                msg,
+                format!(
+                    "Not enough balance for the transfer at Wallet \"{}\"",
+                    from_wallet_xorurl
+                )
+            ),
+            Err(err) => panic!(format!("Error returned is not the expected: {:?}", err)),
+            Ok(_) => panic!("Transfer succeeded unexpectedly"),
+        };
 
-    // test successful transfer
-    match safe.wallet_transfer(
-        "100.3",
-        Some(&from_spendable_balance),
-        &to_wallet_xorurl,
-        None,
-    ) {
-        Err(msg) => panic!(format!("Transfer was expected to succeed: {}", msg)),
-        Ok(_) => {
-            let from_first_current_balance =
-                unwrap!(safe.wallet_balance(&format!("{}/from-first-balance", from_wallet_xorurl)));
-            assert_eq!("100.500000000", from_first_current_balance);
-            let from_second_current_balance = unwrap!(safe.wallet_balance(&from_spendable_balance));
-            assert_eq!(
-                "100.200000000", /* 200.5 - 100.3 */
-                from_second_current_balance
-            );
-            let from_current_balance = unwrap!(safe.wallet_balance(&from_wallet_xorurl));
-            assert_eq!("200.700000000" /* 301 - 100.3 */, from_current_balance);
-            let to_current_balance = unwrap!(safe.wallet_balance(&to_wallet_xorurl));
-            assert_eq!("110.800000000" /* 10.5 + 100.3 */, to_current_balance);
-        }
-    };
-}
+        // test fail to transfer as it's a invalid/non-numeric amount
+        match safe.wallet_transfer(".06", Some(&from_wallet_xorurl), &to_wallet_xorurl, None) {
+            Err(Error::InvalidAmount(msg)) => assert_eq!(
+                msg,
+                "Invalid safecoins amount '.06' (Can\'t parse coin units)"
+            ),
+            Err(err) => panic!(format!("Error returned is not the expected: {:?}", err)),
+            Ok(_) => panic!("Transfer succeeded unexpectedly"),
+        };
 
-#[test]
-fn test_wallet_transfer_to_specific_balance() {
-    use rand::distributions::Alphanumeric;
-    use rand::{thread_rng, Rng};
-    use unwrap::unwrap;
-    let mut safe = Safe::new("base32z");
-    unwrap!(safe.connect("", Some("fake-credentials")));
-    let from_wallet_xorurl = unwrap!(safe.wallet_create());
-    let (_key_xorurl1, key_pair1) = unwrap!(safe.keys_create_preload_test_coins("100.7"));
-    unwrap!(safe.wallet_insert(
-        &from_wallet_xorurl,
-        Some("from-first-balance"),
-        true, // set --default
-        &unwrap!(key_pair1.clone()).sk,
-    ));
+        // test successful transfer
+        match safe.wallet_transfer("100.4", Some(&from_wallet_xorurl), &to_wallet_xorurl, None) {
+            Err(msg) => panic!(format!("Transfer was expected to succeed: {}", msg)),
+            Ok(_) => {
+                let from_current_balance = unwrap!(safe.wallet_balance(&from_wallet_xorurl));
+                assert_eq!("0.100000000", from_current_balance);
+                let to_current_balance = unwrap!(safe.wallet_balance(&to_wallet_xorurl));
+                assert_eq!("100.900000000", to_current_balance);
+            }
+        };
+    }
 
-    let to_wallet_xorurl = unwrap!(safe.wallet_create());
-    let (_key_xorurl2, key_pair2) = unwrap!(safe.keys_create_preload_test_coins("10.2"));
-    unwrap!(safe.wallet_insert(
-        &to_wallet_xorurl,
-        Some("to-first-balance"),
-        true, // set --default
-        &unwrap!(key_pair2.clone()).sk,
-    ));
+    #[test]
+    fn test_wallet_transfer_to_safekey() {
+        use unwrap::unwrap;
+        let mut safe = Safe::new("base32z");
+        unwrap!(safe.connect("", Some("fake-credentials")));
 
-    let (_key_xorurl3, key_pair3) = unwrap!(safe.keys_create_preload_test_coins("20.2"));
-    unwrap!(safe.wallet_insert(
-        &to_wallet_xorurl,
-        Some("to-second-balance"),
-        false,
-        &unwrap!(key_pair3.clone()).sk,
-    ));
+        let from_wallet_xorurl = unwrap!(safe.wallet_create());
+        let (_, key_pair1) = unwrap!(safe.keys_create_preload_test_coins("4621.45"));
+        unwrap!(safe.wallet_insert(
+            &from_wallet_xorurl,
+            Some("my-first-balance"),
+            true, // set --default
+            &unwrap!(key_pair1.clone()).sk,
+        ));
 
-    // test successful transfer to 'to-second-balance'
-    let mut to_wallet_spendable_balance = unwrap!(XorUrlEncoder::from_url(&to_wallet_xorurl));
-    to_wallet_spendable_balance.set_path("to-second-balance");
-    let to_spendable_balance = unwrap!(to_wallet_spendable_balance.to_string());
-    match safe.wallet_transfer(
-        "100.5",
-        Some(&from_wallet_xorurl),
-        &to_spendable_balance,
-        None,
-    ) {
-        Err(msg) => panic!(format!("Transfer was expected to succeed: {}", msg)),
-        Ok(_) => {
-            let from_current_balance = unwrap!(safe.wallet_balance(&from_wallet_xorurl));
-            assert_eq!("0.200000000" /* 100.7 - 100.5 */, from_current_balance);
-            let to_first_current_balance =
-                unwrap!(safe.wallet_balance(&format!("{}/to-first-balance", to_wallet_xorurl)));
-            assert_eq!("10.200000000", to_first_current_balance);
-            let to_second_current_balance = unwrap!(safe.wallet_balance(&to_spendable_balance));
-            assert_eq!(
-                "120.700000000", /* 20.2 + 100.5 */
-                to_second_current_balance
-            );
-            let to_current_balance = unwrap!(safe.wallet_balance(&to_wallet_xorurl));
-            assert_eq!("130.900000000", /* 30.4 + 100.5 */ to_current_balance);
-        }
-    };
+        let (key_xorurl, key_pair2) = unwrap!(safe.keys_create_preload_test_coins("10.0"));
 
-    // let's also test checking the balance with NRS URL of the destination spendable balances
-    let to_wallet_nrsurl: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
-    let _ = unwrap!(safe.nrs_map_container_create(
-        &to_wallet_nrsurl,
-        &to_wallet_xorurl,
-        false,
-        true,
-        false
-    ));
+        // test successful transfer
+        match safe.wallet_transfer("523.87", Some(&from_wallet_xorurl), &key_xorurl, None) {
+            Err(msg) => panic!(format!("Transfer was expected to succeed: {}", msg)),
+            Ok(_) => {
+                let from_current_balance = unwrap!(safe.wallet_balance(&from_wallet_xorurl));
+                assert_eq!(
+                    "4097.580000000", /* 4621.45 - 523.87 */
+                    from_current_balance
+                );
+                let key_current_balance =
+                    unwrap!(safe.keys_balance_from_sk(&unwrap!(key_pair2).sk));
+                assert_eq!("533.870000000", key_current_balance);
+            }
+        };
+    }
 
-    let to_first_current_balance =
-        unwrap!(safe.wallet_balance(&format!("{}/to-first-balance", to_wallet_nrsurl)));
-    assert_eq!("10.200000000", to_first_current_balance);
-    let to_second_current_balance =
-        unwrap!(safe.wallet_balance(&format!("{}/to-second-balance", to_wallet_nrsurl)));
-    assert_eq!("120.700000000", to_second_current_balance);
-}
+    #[test]
+    fn test_wallet_transfer_from_safekey() {
+        use unwrap::unwrap;
+        let mut safe = Safe::new("base32z");
+        unwrap!(safe.connect("", Some("fake-credentials")));
 
-#[test]
-fn test_wallet_transfer_specific_balances_with_nrs_urls() {
-    use rand::distributions::Alphanumeric;
-    use rand::{thread_rng, Rng};
-    use unwrap::unwrap;
-    let mut safe = Safe::new("base32z");
-    unwrap!(safe.connect("", Some("fake-credentials")));
-    let from_wallet_xorurl = unwrap!(safe.wallet_create());
-    let (_key_xorurl1, key_pair1) = unwrap!(safe.keys_create_preload_test_coins("10.1"));
-    unwrap!(safe.wallet_insert(
-        &from_wallet_xorurl,
-        Some("from-first-balance"),
-        true, // set --default
-        &unwrap!(key_pair1.clone()).sk,
-    ));
+        let (safekey_xorurl1, _) = unwrap!(safe.keys_create_preload_test_coins("7"));
+        let (safekey_xorurl2, _) = unwrap!(safe.keys_create_preload_test_coins("0"));
 
-    let (_key_xorurl2, key_pair2) = unwrap!(safe.keys_create_preload_test_coins("20.2"));
-    unwrap!(safe.wallet_insert(
-        &from_wallet_xorurl,
-        Some("from-second-balance"),
-        false,
-        &unwrap!(key_pair2.clone()).sk,
-    ));
+        match safe.wallet_transfer("1", Some(&safekey_xorurl1), &safekey_xorurl2, None) {
+            Ok(_) => panic!("Transfer from SafeKey was expected to fail".to_string()),
+            Err(Error::InvalidInput(msg)) => {
+                assert_eq!(
+                    msg,
+                    "The 'from_url' URL doesn't target a Wallet, it is: Raw (SafeKey)"
+                );
+            }
+            Err(err) => panic!(format!("Error is not the expected one: {:?}", err)),
+        };
+    }
 
-    let to_wallet_xorurl = unwrap!(safe.wallet_create());
-    let (_key_xorurl3, key_pair3) = unwrap!(safe.keys_create_preload_test_coins("30.3"));
-    unwrap!(safe.wallet_insert(
-        &to_wallet_xorurl,
-        Some("to-first-balance"),
-        true, // set --default
-        &unwrap!(key_pair3.clone()).sk,
-    ));
+    #[test]
+    fn test_wallet_transfer_with_nrs_urls() {
+        use rand::distributions::Alphanumeric;
+        use rand::{thread_rng, Rng};
+        use unwrap::unwrap;
+        let mut safe = Safe::new("base32z");
+        unwrap!(safe.connect("", Some("fake-credentials")));
 
-    let (_key_xorurl4, key_pair4) = unwrap!(safe.keys_create_preload_test_coins("40.4"));
-    unwrap!(safe.wallet_insert(
-        &to_wallet_xorurl,
-        Some("to-second-balance"),
-        false,
-        &unwrap!(key_pair4.clone()).sk,
-    ));
+        let from_wallet_xorurl = unwrap!(safe.wallet_create());
+        let (_, key_pair1) = unwrap!(safe.keys_create_preload_test_coins("0.2"));
+        unwrap!(safe.wallet_insert(
+            &from_wallet_xorurl,
+            Some("my-first-balance"),
+            true, // set --default
+            &unwrap!(key_pair1.clone()).sk,
+        ));
 
-    // create NRS URLs for both wallets
-    let from_nrsurl: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
-    let _ = unwrap!(safe.nrs_map_container_create(
-        &from_nrsurl,
-        &from_wallet_xorurl,
-        false,
-        true,
-        false
-    ));
-    let to_nrsurl: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
-    let _ =
-        unwrap!(safe.nrs_map_container_create(&to_nrsurl, &to_wallet_xorurl, false, true, false));
+        let from_nrsurl: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
+        let _ = unwrap!(safe.nrs_map_container_create(
+            &from_nrsurl,
+            &from_wallet_xorurl,
+            false,
+            true,
+            false
+        ));
 
-    // test successful transfer from 'from-second-balance' to 'to-second-balance'
-    let from_spendable_balance = format!("{}/from-second-balance", from_nrsurl);
-    let to_spendable_balance = format!("{}/to-second-balance", to_nrsurl);
-    match safe.wallet_transfer(
-        "5.8",
-        Some(&from_spendable_balance),
-        &to_spendable_balance,
-        None,
-    ) {
-        Err(msg) => panic!(format!("Transfer was expected to succeed: {}", msg)),
-        Ok(_) => {
-            let from_current_balance = unwrap!(safe.wallet_balance(&from_wallet_xorurl));
-            assert_eq!(
-                "24.500000000", /* 10.1 + 20.2 - 5.8 */
-                from_current_balance
-            );
-            let from_first_current_balance =
-                unwrap!(safe.wallet_balance(&format!("{}/from-first-balance", from_wallet_xorurl)));
-            assert_eq!("10.100000000", from_first_current_balance);
-            let from_second_current_balance = unwrap!(safe.wallet_balance(&from_spendable_balance));
-            assert_eq!(
-                "14.400000000", /* 20.2 - 5.8 */
-                from_second_current_balance
-            );
+        let (key_xorurl, key_pair2) = unwrap!(safe.keys_create_preload_test_coins("0.1"));
+        let to_nrsurl: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
+        let _ = unwrap!(safe.nrs_map_container_create(&to_nrsurl, &key_xorurl, false, true, false));
 
-            let to_current_balance = unwrap!(safe.wallet_balance(&to_wallet_xorurl));
-            assert_eq!(
-                "76.500000000",
-                /* 30.3 + 40.4 + 5.8 */ to_current_balance
-            );
-            let to_first_current_balance =
-                unwrap!(safe.wallet_balance(&format!("{}/to-first-balance", to_wallet_xorurl)));
-            assert_eq!("30.300000000", to_first_current_balance);
-            let to_second_current_balance = unwrap!(safe.wallet_balance(&to_spendable_balance));
-            assert_eq!(
-                "46.200000000", /* 40.4 + 5.8 */
-                to_second_current_balance
-            );
-        }
-    };
-}
+        // test successful transfer
+        match safe.wallet_transfer("0.2", Some(&from_nrsurl), &to_nrsurl, None) {
+            Err(msg) => panic!(format!("Transfer was expected to succeed: {}", msg)),
+            Ok(_) => {
+                let from_current_balance = unwrap!(safe.wallet_balance(&from_nrsurl));
+                assert_eq!("0.000000000" /* 0.2 - 0.2 */, from_current_balance);
+                let key_current_balance =
+                    unwrap!(safe.keys_balance_from_sk(&unwrap!(key_pair2).sk));
+                assert_eq!("0.300000000" /* 0.1 + 0.2 */, key_current_balance);
+            }
+        };
+    }
 
-#[test]
-#[cfg(not(feature = "scl-mock"))]
-fn test_wallet_transfer_from_not_owned_wallet() {
-    use unwrap::unwrap;
-    let mut safe = Safe::new("base32z");
-    unwrap!(safe.connect("", Some("fake-credentials")));
-    let account1_wallet_xorurl = unwrap!(safe.wallet_create());
-    let (_key_xorurl1, key_pair1) = unwrap!(safe.keys_create_preload_test_coins("100.5"));
-    unwrap!(safe.wallet_insert(
-        &account1_wallet_xorurl,
-        Some("my-first-balance"),
-        true, // set --default
-        &unwrap!(key_pair1.clone()).sk,
-    ));
+    #[test]
+    fn test_wallet_transfer_from_specific_balance() {
+        use unwrap::unwrap;
+        let mut safe = Safe::new("base32z");
+        unwrap!(safe.connect("", Some("fake-credentials")));
+        let from_wallet_xorurl = unwrap!(safe.wallet_create());
+        let (_key_xorurl1, key_pair1) = unwrap!(safe.keys_create_preload_test_coins("100.5"));
+        unwrap!(safe.wallet_insert(
+            &from_wallet_xorurl,
+            Some("from-first-balance"),
+            true, // set --default
+            &unwrap!(key_pair1.clone()).sk,
+        ));
 
-    let mut another_safe = Safe::new("base32z");
-    unwrap!(another_safe.connect("", Some("another-fake-credentials")));
-    let (key_xorurl, _key_pair) = unwrap!(another_safe.keys_create_preload_test_coins("100.5"));
+        let (_key_xorurl2, key_pair2) = unwrap!(safe.keys_create_preload_test_coins("200.5"));
+        unwrap!(safe.wallet_insert(
+            &from_wallet_xorurl,
+            Some("from-second-balance"),
+            false,
+            &unwrap!(key_pair2.clone()).sk,
+        ));
 
-    // test fail to transfer from a not owned wallet in <from> argument
-    match another_safe.wallet_transfer("0.2", Some(&account1_wallet_xorurl), &key_xorurl, None) {
-        Err(Error::AccessDenied(msg)) => assert_eq!(
-            msg,
-            format!(
-                "Couldn't read source Wallet for the transfer at \"{}\"",
-                account1_wallet_xorurl
-            )
-        ),
-        Err(err) => panic!(format!("Error returned is not the expected: {:?}", err)),
-        Ok(_) => panic!("Transfer succeeded unexpectedly"),
-    };
+        let to_wallet_xorurl = unwrap!(safe.wallet_create());
+        let (_key_xorurl3, key_pair3) = unwrap!(safe.keys_create_preload_test_coins("10.5"));
+        unwrap!(safe.wallet_insert(
+            &to_wallet_xorurl,
+            Some("to-first-balance"),
+            true, // set --default
+            &unwrap!(key_pair3.clone()).sk,
+        ));
+
+        // test fail to transfer more than current balance at 'from-firstbaance'
+        let mut from_wallet_spendable_balance =
+            unwrap!(XorUrlEncoder::from_url(&from_wallet_xorurl));
+        from_wallet_spendable_balance.set_path("from-second-balance");
+        let from_spendable_balance = unwrap!(from_wallet_spendable_balance.to_string());
+        match safe.wallet_transfer(
+            "200.6",
+            Some(&from_spendable_balance),
+            &to_wallet_xorurl,
+            None,
+        ) {
+            Err(Error::NotEnoughBalance(msg)) => assert_eq!(
+                msg,
+                format!(
+                    "Not enough balance for the transfer at Wallet \"{}\"",
+                    from_spendable_balance
+                )
+            ),
+            Err(err) => panic!(format!("Error returned is not the expected: {:?}", err)),
+            Ok(_) => panic!("Transfer succeeded unexpectedly"),
+        };
+
+        // test successful transfer
+        match safe.wallet_transfer(
+            "100.3",
+            Some(&from_spendable_balance),
+            &to_wallet_xorurl,
+            None,
+        ) {
+            Err(msg) => panic!(format!("Transfer was expected to succeed: {}", msg)),
+            Ok(_) => {
+                let from_first_current_balance = unwrap!(
+                    safe.wallet_balance(&format!("{}/from-first-balance", from_wallet_xorurl))
+                );
+                assert_eq!("100.500000000", from_first_current_balance);
+                let from_second_current_balance =
+                    unwrap!(safe.wallet_balance(&from_spendable_balance));
+                assert_eq!(
+                    "100.200000000", /* 200.5 - 100.3 */
+                    from_second_current_balance
+                );
+                let from_current_balance = unwrap!(safe.wallet_balance(&from_wallet_xorurl));
+                assert_eq!("200.700000000" /* 301 - 100.3 */, from_current_balance);
+                let to_current_balance = unwrap!(safe.wallet_balance(&to_wallet_xorurl));
+                assert_eq!("110.800000000" /* 10.5 + 100.3 */, to_current_balance);
+            }
+        };
+    }
+
+    #[test]
+    fn test_wallet_transfer_to_specific_balance() {
+        use rand::distributions::Alphanumeric;
+        use rand::{thread_rng, Rng};
+        use unwrap::unwrap;
+        let mut safe = Safe::new("base32z");
+        unwrap!(safe.connect("", Some("fake-credentials")));
+        let from_wallet_xorurl = unwrap!(safe.wallet_create());
+        let (_key_xorurl1, key_pair1) = unwrap!(safe.keys_create_preload_test_coins("100.7"));
+        unwrap!(safe.wallet_insert(
+            &from_wallet_xorurl,
+            Some("from-first-balance"),
+            true, // set --default
+            &unwrap!(key_pair1.clone()).sk,
+        ));
+
+        let to_wallet_xorurl = unwrap!(safe.wallet_create());
+        let (_key_xorurl2, key_pair2) = unwrap!(safe.keys_create_preload_test_coins("10.2"));
+        unwrap!(safe.wallet_insert(
+            &to_wallet_xorurl,
+            Some("to-first-balance"),
+            true, // set --default
+            &unwrap!(key_pair2.clone()).sk,
+        ));
+
+        let (_key_xorurl3, key_pair3) = unwrap!(safe.keys_create_preload_test_coins("20.2"));
+        unwrap!(safe.wallet_insert(
+            &to_wallet_xorurl,
+            Some("to-second-balance"),
+            false,
+            &unwrap!(key_pair3.clone()).sk,
+        ));
+
+        // test successful transfer to 'to-second-balance'
+        let mut to_wallet_spendable_balance = unwrap!(XorUrlEncoder::from_url(&to_wallet_xorurl));
+        to_wallet_spendable_balance.set_path("to-second-balance");
+        let to_spendable_balance = unwrap!(to_wallet_spendable_balance.to_string());
+        match safe.wallet_transfer(
+            "100.5",
+            Some(&from_wallet_xorurl),
+            &to_spendable_balance,
+            None,
+        ) {
+            Err(msg) => panic!(format!("Transfer was expected to succeed: {}", msg)),
+            Ok(_) => {
+                let from_current_balance = unwrap!(safe.wallet_balance(&from_wallet_xorurl));
+                assert_eq!("0.200000000" /* 100.7 - 100.5 */, from_current_balance);
+                let to_first_current_balance =
+                    unwrap!(safe.wallet_balance(&format!("{}/to-first-balance", to_wallet_xorurl)));
+                assert_eq!("10.200000000", to_first_current_balance);
+                let to_second_current_balance = unwrap!(safe.wallet_balance(&to_spendable_balance));
+                assert_eq!(
+                    "120.700000000", /* 20.2 + 100.5 */
+                    to_second_current_balance
+                );
+                let to_current_balance = unwrap!(safe.wallet_balance(&to_wallet_xorurl));
+                assert_eq!("130.900000000", /* 30.4 + 100.5 */ to_current_balance);
+            }
+        };
+
+        // let's also test checking the balance with NRS URL of the destination spendable balances
+        let to_wallet_nrsurl: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
+        let _ = unwrap!(safe.nrs_map_container_create(
+            &to_wallet_nrsurl,
+            &to_wallet_xorurl,
+            false,
+            true,
+            false
+        ));
+
+        let to_first_current_balance =
+            unwrap!(safe.wallet_balance(&format!("{}/to-first-balance", to_wallet_nrsurl)));
+        assert_eq!("10.200000000", to_first_current_balance);
+        let to_second_current_balance =
+            unwrap!(safe.wallet_balance(&format!("{}/to-second-balance", to_wallet_nrsurl)));
+        assert_eq!("120.700000000", to_second_current_balance);
+    }
+
+    #[test]
+    fn test_wallet_transfer_specific_balances_with_nrs_urls() {
+        use rand::distributions::Alphanumeric;
+        use rand::{thread_rng, Rng};
+        use unwrap::unwrap;
+        let mut safe = Safe::new("base32z");
+        unwrap!(safe.connect("", Some("fake-credentials")));
+        let from_wallet_xorurl = unwrap!(safe.wallet_create());
+        let (_key_xorurl1, key_pair1) = unwrap!(safe.keys_create_preload_test_coins("10.1"));
+        unwrap!(safe.wallet_insert(
+            &from_wallet_xorurl,
+            Some("from-first-balance"),
+            true, // set --default
+            &unwrap!(key_pair1.clone()).sk,
+        ));
+
+        let (_key_xorurl2, key_pair2) = unwrap!(safe.keys_create_preload_test_coins("20.2"));
+        unwrap!(safe.wallet_insert(
+            &from_wallet_xorurl,
+            Some("from-second-balance"),
+            false,
+            &unwrap!(key_pair2.clone()).sk,
+        ));
+
+        let to_wallet_xorurl = unwrap!(safe.wallet_create());
+        let (_key_xorurl3, key_pair3) = unwrap!(safe.keys_create_preload_test_coins("30.3"));
+        unwrap!(safe.wallet_insert(
+            &to_wallet_xorurl,
+            Some("to-first-balance"),
+            true, // set --default
+            &unwrap!(key_pair3.clone()).sk,
+        ));
+
+        let (_key_xorurl4, key_pair4) = unwrap!(safe.keys_create_preload_test_coins("40.4"));
+        unwrap!(safe.wallet_insert(
+            &to_wallet_xorurl,
+            Some("to-second-balance"),
+            false,
+            &unwrap!(key_pair4.clone()).sk,
+        ));
+
+        // create NRS URLs for both wallets
+        let from_nrsurl: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
+        let _ = unwrap!(safe.nrs_map_container_create(
+            &from_nrsurl,
+            &from_wallet_xorurl,
+            false,
+            true,
+            false
+        ));
+        let to_nrsurl: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
+        let _ = unwrap!(safe.nrs_map_container_create(
+            &to_nrsurl,
+            &to_wallet_xorurl,
+            false,
+            true,
+            false
+        ));
+
+        // test successful transfer from 'from-second-balance' to 'to-second-balance'
+        let from_spendable_balance = format!("{}/from-second-balance", from_nrsurl);
+        let to_spendable_balance = format!("{}/to-second-balance", to_nrsurl);
+        match safe.wallet_transfer(
+            "5.8",
+            Some(&from_spendable_balance),
+            &to_spendable_balance,
+            None,
+        ) {
+            Err(msg) => panic!(format!("Transfer was expected to succeed: {}", msg)),
+            Ok(_) => {
+                let from_current_balance = unwrap!(safe.wallet_balance(&from_wallet_xorurl));
+                assert_eq!(
+                    "24.500000000", /* 10.1 + 20.2 - 5.8 */
+                    from_current_balance
+                );
+                let from_first_current_balance = unwrap!(
+                    safe.wallet_balance(&format!("{}/from-first-balance", from_wallet_xorurl))
+                );
+                assert_eq!("10.100000000", from_first_current_balance);
+                let from_second_current_balance =
+                    unwrap!(safe.wallet_balance(&from_spendable_balance));
+                assert_eq!(
+                    "14.400000000", /* 20.2 - 5.8 */
+                    from_second_current_balance
+                );
+
+                let to_current_balance = unwrap!(safe.wallet_balance(&to_wallet_xorurl));
+                assert_eq!(
+                    "76.500000000",
+                    /* 30.3 + 40.4 + 5.8 */ to_current_balance
+                );
+                let to_first_current_balance =
+                    unwrap!(safe.wallet_balance(&format!("{}/to-first-balance", to_wallet_xorurl)));
+                assert_eq!("30.300000000", to_first_current_balance);
+                let to_second_current_balance = unwrap!(safe.wallet_balance(&to_spendable_balance));
+                assert_eq!(
+                    "46.200000000", /* 40.4 + 5.8 */
+                    to_second_current_balance
+                );
+            }
+        };
+    }
+
+    #[test]
+    #[cfg(not(feature = "scl-mock"))]
+    fn test_wallet_transfer_from_not_owned_wallet() {
+        use unwrap::unwrap;
+        let mut safe = Safe::new("base32z");
+        unwrap!(safe.connect("", Some("fake-credentials")));
+        let account1_wallet_xorurl = unwrap!(safe.wallet_create());
+        let (_key_xorurl1, key_pair1) = unwrap!(safe.keys_create_preload_test_coins("100.5"));
+        unwrap!(safe.wallet_insert(
+            &account1_wallet_xorurl,
+            Some("my-first-balance"),
+            true, // set --default
+            &unwrap!(key_pair1.clone()).sk,
+        ));
+
+        let mut another_safe = Safe::new("base32z");
+        unwrap!(another_safe.connect("", Some("another-fake-credentials")));
+        let (key_xorurl, _key_pair) = unwrap!(another_safe.keys_create_preload_test_coins("100.5"));
+
+        // test fail to transfer from a not owned wallet in <from> argument
+        match another_safe.wallet_transfer("0.2", Some(&account1_wallet_xorurl), &key_xorurl, None)
+        {
+            Err(Error::AccessDenied(msg)) => assert_eq!(
+                msg,
+                format!(
+                    "Couldn't read source Wallet for the transfer at \"{}\"",
+                    account1_wallet_xorurl
+                )
+            ),
+            Err(err) => panic!(format!("Error returned is not the expected: {:?}", err)),
+            Ok(_) => panic!("Transfer succeeded unexpectedly"),
+        };
+    }
 }

--- a/safe-api/src/api/xorurl.rs
+++ b/safe-api/src/api/xorurl.rs
@@ -155,7 +155,7 @@ impl XorUrlEncoder {
         MEDIA_TYPE_CODES.get(media_type).is_some()
     }
 
-    // A non-member encoder function for convinience in some cases
+    // A non-member encoder function for convenience in some cases
     #[allow(clippy::too_many_arguments)]
     pub fn encode(
         xorname: XorName,
@@ -397,210 +397,215 @@ impl fmt::Display for XorUrlEncoder {
     }
 }
 
-#[test]
-fn test_xorurl_base32_encoding() {
-    use unwrap::unwrap;
-    let xorname = XorName(*b"12345678901234567890123456789012");
-    let xorurl = unwrap!(XorUrlEncoder::encode(
-        xorname,
-        0xa632_3c4d_4a32,
-        SafeDataType::PublishedImmutableData,
-        SafeContentType::Raw,
-        None,
-        None,
-        None,
-        "base32"
-    ));
-    let base32_xorurl =
-        "safe://biaaaatcmrtgq2tmnzyheydcmrtgq2tmnzyheydcmrtgq2tmnzyheydcmvggi6e2srs";
-    assert_eq!(xorurl, base32_xorurl);
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-#[test]
-fn test_xorurl_base32z_encoding() {
-    use unwrap::unwrap;
-    let xorname = XorName(*b"12345678901234567890123456789012");
-    let xorurl = unwrap!(XorUrlEncoder::encode(
-        xorname,
-        0,
-        SafeDataType::PublishedImmutableData,
-        SafeContentType::Raw,
-        None,
-        None,
-        None,
-        "base32z"
-    ));
-    let base32z_xorurl = "safe://hbyyyyncj1gc4dkptz8yhuycj1gc4dkptz8yhuycj1gc4dkptz8yhuycj1";
-    assert_eq!(xorurl, base32z_xorurl);
-}
+    #[test]
+    fn test_xorurl_base32_encoding() {
+        use unwrap::unwrap;
+        let xorname = XorName(*b"12345678901234567890123456789012");
+        let xorurl = unwrap!(XorUrlEncoder::encode(
+            xorname,
+            0xa632_3c4d_4a32,
+            SafeDataType::PublishedImmutableData,
+            SafeContentType::Raw,
+            None,
+            None,
+            None,
+            "base32"
+        ));
+        let base32_xorurl =
+            "safe://biaaaatcmrtgq2tmnzyheydcmrtgq2tmnzyheydcmrtgq2tmnzyheydcmvggi6e2srs";
+        assert_eq!(xorurl, base32_xorurl);
+    }
 
-#[test]
-fn test_xorurl_base64_encoding() {
-    use unwrap::unwrap;
-    let xorname = XorName(*b"12345678901234567890123456789012");
-    let xorurl = unwrap!(XorUrlEncoder::encode(
-        xorname,
-        4_584_545,
-        SafeDataType::PublishedSeqAppendOnlyData,
-        SafeContentType::FilesContainer,
-        None,
-        None,
-        None,
-        "base64"
-    ));
-    let base64_xorurl = "safe://mQACBTEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyRfRh";
-    assert_eq!(xorurl, base64_xorurl);
-    let xorurl_encoder = unwrap!(XorUrlEncoder::from_url(&base64_xorurl));
-    assert_eq!(base64_xorurl, unwrap!(xorurl_encoder.to_base("base64")));
-    assert_eq!("", xorurl_encoder.path());
-    assert_eq!(XOR_URL_VERSION_1, xorurl_encoder.encoding_version());
-    assert_eq!(xorname, xorurl_encoder.xorname());
-    assert_eq!(4_584_545, xorurl_encoder.type_tag());
-    assert_eq!(
-        SafeDataType::PublishedSeqAppendOnlyData,
-        xorurl_encoder.data_type()
-    );
-    assert_eq!(
-        SafeContentType::FilesContainer,
-        xorurl_encoder.content_type()
-    );
-}
+    #[test]
+    fn test_xorurl_base32z_encoding() {
+        use unwrap::unwrap;
+        let xorname = XorName(*b"12345678901234567890123456789012");
+        let xorurl = unwrap!(XorUrlEncoder::encode(
+            xorname,
+            0,
+            SafeDataType::PublishedImmutableData,
+            SafeContentType::Raw,
+            None,
+            None,
+            None,
+            "base32z"
+        ));
+        let base32z_xorurl = "safe://hbyyyyncj1gc4dkptz8yhuycj1gc4dkptz8yhuycj1gc4dkptz8yhuycj1";
+        assert_eq!(xorurl, base32z_xorurl);
+    }
 
-#[test]
-fn test_xorurl_default_base_encoding() {
-    use unwrap::unwrap;
-    let xorname = XorName(*b"12345678901234567890123456789012");
-    let base32z_xorurl = "safe://hbyyyyncj1gc4dkptz8yhuycj1gc4dkptz8yhuycj1gc4dkptz8yhuycj1";
-    let xorurl = unwrap!(XorUrlEncoder::encode(
-        xorname,
-        0,
-        SafeDataType::PublishedImmutableData,
-        SafeContentType::Raw,
-        None,
-        None,
-        None,
-        "" // forces it to use the default
-    ));
-    assert_eq!(xorurl, base32z_xorurl);
-}
+    #[test]
+    fn test_xorurl_base64_encoding() {
+        use unwrap::unwrap;
+        let xorname = XorName(*b"12345678901234567890123456789012");
+        let xorurl = unwrap!(XorUrlEncoder::encode(
+            xorname,
+            4_584_545,
+            SafeDataType::PublishedSeqAppendOnlyData,
+            SafeContentType::FilesContainer,
+            None,
+            None,
+            None,
+            "base64"
+        ));
+        let base64_xorurl = "safe://mQACBTEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyRfRh";
+        assert_eq!(xorurl, base64_xorurl);
+        let xorurl_encoder = unwrap!(XorUrlEncoder::from_url(&base64_xorurl));
+        assert_eq!(base64_xorurl, unwrap!(xorurl_encoder.to_base("base64")));
+        assert_eq!("", xorurl_encoder.path());
+        assert_eq!(XOR_URL_VERSION_1, xorurl_encoder.encoding_version());
+        assert_eq!(xorname, xorurl_encoder.xorname());
+        assert_eq!(4_584_545, xorurl_encoder.type_tag());
+        assert_eq!(
+            SafeDataType::PublishedSeqAppendOnlyData,
+            xorurl_encoder.data_type()
+        );
+        assert_eq!(
+            SafeContentType::FilesContainer,
+            xorurl_encoder.content_type()
+        );
+    }
 
-#[test]
-fn test_xorurl_decoding() {
-    use unwrap::unwrap;
-    let xorname = XorName(*b"12345678901234567890123456789012");
-    let type_tag: u64 = 0x0eef;
-    let xorurl_encoder = unwrap!(XorUrlEncoder::new(
-        xorname,
-        type_tag,
-        SafeDataType::PublishedImmutableData,
-        SafeContentType::Raw,
-        None,
-        None,
-        None,
-    ));
-    assert_eq!("", xorurl_encoder.path());
-    assert_eq!(XOR_URL_VERSION_1, xorurl_encoder.encoding_version());
-    assert_eq!(xorname, xorurl_encoder.xorname());
-    assert_eq!(type_tag, xorurl_encoder.type_tag());
-    assert_eq!(
-        SafeDataType::PublishedImmutableData,
-        xorurl_encoder.data_type()
-    );
-    assert_eq!(SafeContentType::Raw, xorurl_encoder.content_type());
-}
+    #[test]
+    fn test_xorurl_default_base_encoding() {
+        use unwrap::unwrap;
+        let xorname = XorName(*b"12345678901234567890123456789012");
+        let base32z_xorurl = "safe://hbyyyyncj1gc4dkptz8yhuycj1gc4dkptz8yhuycj1gc4dkptz8yhuycj1";
+        let xorurl = unwrap!(XorUrlEncoder::encode(
+            xorname,
+            0,
+            SafeDataType::PublishedImmutableData,
+            SafeContentType::Raw,
+            None,
+            None,
+            None,
+            "" // forces it to use the default
+        ));
+        assert_eq!(xorurl, base32z_xorurl);
+    }
 
-#[test]
-fn test_xorurl_decoding_with_path() {
-    use unwrap::unwrap;
-    let xorname = XorName(*b"12345678901234567890123456789012");
-    let type_tag: u64 = 0x0eef;
-    let xorurl = unwrap!(XorUrlEncoder::encode(
-        xorname,
-        type_tag,
-        SafeDataType::PublishedSeqAppendOnlyData,
-        SafeContentType::Wallet,
-        None,
-        None,
-        None,
-        "base32z"
-    ));
+    #[test]
+    fn test_xorurl_decoding() {
+        use unwrap::unwrap;
+        let xorname = XorName(*b"12345678901234567890123456789012");
+        let type_tag: u64 = 0x0eef;
+        let xorurl_encoder = unwrap!(XorUrlEncoder::new(
+            xorname,
+            type_tag,
+            SafeDataType::PublishedImmutableData,
+            SafeContentType::Raw,
+            None,
+            None,
+            None,
+        ));
+        assert_eq!("", xorurl_encoder.path());
+        assert_eq!(XOR_URL_VERSION_1, xorurl_encoder.encoding_version());
+        assert_eq!(xorname, xorurl_encoder.xorname());
+        assert_eq!(type_tag, xorurl_encoder.type_tag());
+        assert_eq!(
+            SafeDataType::PublishedImmutableData,
+            xorurl_encoder.data_type()
+        );
+        assert_eq!(SafeContentType::Raw, xorurl_encoder.content_type());
+    }
 
-    let xorurl_with_path = format!("{}/subfolder/file", xorurl);
-    let xorurl_encoder_with_path = unwrap!(XorUrlEncoder::from_url(&xorurl_with_path));
-    assert_eq!(
-        xorurl_with_path,
-        unwrap!(xorurl_encoder_with_path.to_base("base32z"))
-    );
-    assert_eq!("/subfolder/file", xorurl_encoder_with_path.path());
-    assert_eq!(
-        XOR_URL_VERSION_1,
-        xorurl_encoder_with_path.encoding_version()
-    );
-    assert_eq!(xorname, xorurl_encoder_with_path.xorname());
-    assert_eq!(type_tag, xorurl_encoder_with_path.type_tag());
-    assert_eq!(
-        SafeDataType::PublishedSeqAppendOnlyData,
-        xorurl_encoder_with_path.data_type()
-    );
-    assert_eq!(
-        SafeContentType::Wallet,
-        xorurl_encoder_with_path.content_type()
-    );
-}
+    #[test]
+    fn test_xorurl_decoding_with_path() {
+        use unwrap::unwrap;
+        let xorname = XorName(*b"12345678901234567890123456789012");
+        let type_tag: u64 = 0x0eef;
+        let xorurl = unwrap!(XorUrlEncoder::encode(
+            xorname,
+            type_tag,
+            SafeDataType::PublishedSeqAppendOnlyData,
+            SafeContentType::Wallet,
+            None,
+            None,
+            None,
+            "base32z"
+        ));
 
-#[test]
-fn test_xorurl_decoding_with_subname() {
-    use unwrap::unwrap;
-    let xorname = XorName(*b"12345678901234567890123456789012");
-    let type_tag: u64 = 0x0eef;
-    let xorurl = unwrap!(XorUrlEncoder::encode(
-        xorname,
-        type_tag,
-        SafeDataType::PublishedImmutableData,
-        SafeContentType::NrsMapContainer,
-        None,
-        Some(vec!("sub".to_string())),
-        None,
-        "base32z"
-    ));
+        let xorurl_with_path = format!("{}/subfolder/file", xorurl);
+        let xorurl_encoder_with_path = unwrap!(XorUrlEncoder::from_url(&xorurl_with_path));
+        assert_eq!(
+            xorurl_with_path,
+            unwrap!(xorurl_encoder_with_path.to_base("base32z"))
+        );
+        assert_eq!("/subfolder/file", xorurl_encoder_with_path.path());
+        assert_eq!(
+            XOR_URL_VERSION_1,
+            xorurl_encoder_with_path.encoding_version()
+        );
+        assert_eq!(xorname, xorurl_encoder_with_path.xorname());
+        assert_eq!(type_tag, xorurl_encoder_with_path.type_tag());
+        assert_eq!(
+            SafeDataType::PublishedSeqAppendOnlyData,
+            xorurl_encoder_with_path.data_type()
+        );
+        assert_eq!(
+            SafeContentType::Wallet,
+            xorurl_encoder_with_path.content_type()
+        );
+    }
 
-    let xorurl_with_subname = xorurl.to_string();
-    assert!(xorurl_with_subname.contains("safe://sub."));
-    let xorurl_encoder_with_subname = unwrap!(XorUrlEncoder::from_url(&xorurl_with_subname));
-    assert_eq!(
-        xorurl_with_subname,
-        unwrap!(xorurl_encoder_with_subname.to_base("base32z"))
-    );
-    assert_eq!("", xorurl_encoder_with_subname.path());
-    assert_eq!(1, xorurl_encoder_with_subname.encoding_version());
-    assert_eq!(xorname, xorurl_encoder_with_subname.xorname());
-    assert_eq!(type_tag, xorurl_encoder_with_subname.type_tag());
-    assert_eq!(vec!("sub"), xorurl_encoder_with_subname.sub_names());
-    assert_eq!(
-        SafeContentType::NrsMapContainer,
-        xorurl_encoder_with_subname.content_type()
-    );
-}
+    #[test]
+    fn test_xorurl_decoding_with_subname() {
+        use unwrap::unwrap;
+        let xorname = XorName(*b"12345678901234567890123456789012");
+        let type_tag: u64 = 0x0eef;
+        let xorurl = unwrap!(XorUrlEncoder::encode(
+            xorname,
+            type_tag,
+            SafeDataType::PublishedImmutableData,
+            SafeContentType::NrsMapContainer,
+            None,
+            Some(vec!("sub".to_string())),
+            None,
+            "base32z"
+        ));
 
-#[test]
-fn test_xorurl_encoding_decoding_with_media_type() {
-    use unwrap::unwrap;
-    let xorname = XorName(*b"12345678901234567890123456789012");
-    let type_tag: u64 = 0x4c2f;
-    let xorurl = unwrap!(XorUrlEncoder::encode(
-        xorname,
-        type_tag,
-        SafeDataType::PublishedImmutableData,
-        SafeContentType::MediaType("text/html".to_string()),
-        None,
-        None,
-        None,
-        "base32z"
-    ));
+        let xorurl_with_subname = xorurl.to_string();
+        assert!(xorurl_with_subname.contains("safe://sub."));
+        let xorurl_encoder_with_subname = unwrap!(XorUrlEncoder::from_url(&xorurl_with_subname));
+        assert_eq!(
+            xorurl_with_subname,
+            unwrap!(xorurl_encoder_with_subname.to_base("base32z"))
+        );
+        assert_eq!("", xorurl_encoder_with_subname.path());
+        assert_eq!(1, xorurl_encoder_with_subname.encoding_version());
+        assert_eq!(xorname, xorurl_encoder_with_subname.xorname());
+        assert_eq!(type_tag, xorurl_encoder_with_subname.type_tag());
+        assert_eq!(vec!("sub"), xorurl_encoder_with_subname.sub_names());
+        assert_eq!(
+            SafeContentType::NrsMapContainer,
+            xorurl_encoder_with_subname.content_type()
+        );
+    }
 
-    let xorurl_encoder = unwrap!(XorUrlEncoder::from_url(&xorurl));
-    assert_eq!(
-        SafeContentType::MediaType("text/html".to_string()),
-        xorurl_encoder.content_type()
-    );
+    #[test]
+    fn test_xorurl_encoding_decoding_with_media_type() {
+        use unwrap::unwrap;
+        let xorname = XorName(*b"12345678901234567890123456789012");
+        let type_tag: u64 = 0x4c2f;
+        let xorurl = unwrap!(XorUrlEncoder::encode(
+            xorname,
+            type_tag,
+            SafeDataType::PublishedImmutableData,
+            SafeContentType::MediaType("text/html".to_string()),
+            None,
+            None,
+            None,
+            "base32z"
+        ));
+
+        let xorurl_encoder = unwrap!(XorUrlEncoder::from_url(&xorurl));
+        assert_eq!(
+            SafeContentType::MediaType("text/html".to_string()),
+            xorurl_encoder.content_type()
+        );
+    }
 }


### PR DESCRIPTION
Benefits of doing this:

- It is idiomatic for unit tests to go into a `#[cfg(test)]`-gated `tests`
module.
- This results in better organization of the code.
- Unit tests are not built along with regular code when running `cargo
build` (not sure if this is true for functions marked `#[test]`)
