### PR TITLE
feat(fetch): add a new API which allows to inspect a safe URL without retrieving the actual content

### DIFF
--- a/safe-api/src/api/errors.rs
+++ b/safe-api/src/api/errors.rs
@@ -38,39 +38,14 @@ pub enum Error {
 
 impl From<Error> for String {
     fn from(error: Error) -> String {
-        get_error_info(&error)
+        error.description()
     }
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", get_error_info(self))
+        write!(f, "{}", self.description())
     }
-}
-
-fn get_error_info(error: &Error) -> String {
-    let (error_type, error_msg) = match error {
-        Error::AuthError(info) => ("AuthError".to_string(), info.to_string()),
-        Error::ConnectionError(info) => ("ConnectionError".to_string(), info.to_string()),
-        Error::NetDataError(info) => ("NetDataError".to_string(), info.to_string()),
-        Error::ContentNotFound(info) => ("ContentNotFound".to_string(), info.to_string()),
-        Error::VersionNotFound(info) => ("VersionNotFound".to_string(), info.to_string()),
-        Error::ContentError(info) => ("ContentError".to_string(), info.to_string()),
-        Error::EmptyContent(info) => ("EmptyContent".to_string(), info.to_string()),
-        Error::AccessDenied(info) => ("AccessDenied".to_string(), info.to_string()),
-        Error::EntryNotFound(info) => ("EntryNotFound".to_string(), info.to_string()),
-        Error::EntryExists(info) => ("EntryExists".to_string(), info.to_string()),
-        Error::InvalidInput(info) => ("InvalidInput".to_string(), info.to_string()),
-        Error::InvalidAmount(info) => ("InvalidAmount".to_string(), info.to_string()),
-        Error::InvalidXorUrl(info) => ("InvalidXorUrl".to_string(), info.to_string()),
-        Error::InvalidMediaType(info) => ("InvalidMediaType".to_string(), info.to_string()),
-        Error::NotEnoughBalance(info) => ("NotEnoughBalance".to_string(), info.to_string()),
-        Error::FilesSystemError(info) => ("FilesSystemError".to_string(), info.to_string()),
-        Error::Unexpected(info) => ("Unexpected".to_string(), info.to_string()),
-        Error::Unknown(info) => ("Unknown".to_string(), info.to_string()),
-        Error::StringError(info) => ("StringError".to_string(), info.to_string()),
-    };
-    format!("[Error] {} - {}", error_type, error_msg)
 }
 
 #[allow(missing_docs)]
@@ -103,8 +78,8 @@ mod codes {
     pub const ERR_STRING_ERROR: i32 = -502;
 }
 
-impl ErrorCode for Error {
-    fn error_code(&self) -> i32 {
+impl Error {
+    pub fn error_code(&self) -> i32 {
         match *self {
             Error::AuthError(ref _error) => ERR_AUTH_ERROR,
             Error::ConnectionError(ref _error) => ERR_CONNECTION_ERROR,
@@ -126,6 +101,37 @@ impl ErrorCode for Error {
             Error::Unknown(ref _error) => ERR_UNKNOWN_ERROR,
             Error::StringError(ref _error) => ERR_STRING_ERROR,
         }
+    }
+
+    pub fn description(&self) -> String {
+        let (error_type, error_msg) = match self {
+            Error::AuthError(info) => ("AuthError".to_string(), info.to_string()),
+            Error::ConnectionError(info) => ("ConnectionError".to_string(), info.to_string()),
+            Error::NetDataError(info) => ("NetDataError".to_string(), info.to_string()),
+            Error::ContentNotFound(info) => ("ContentNotFound".to_string(), info.to_string()),
+            Error::VersionNotFound(info) => ("VersionNotFound".to_string(), info.to_string()),
+            Error::ContentError(info) => ("ContentError".to_string(), info.to_string()),
+            Error::EmptyContent(info) => ("EmptyContent".to_string(), info.to_string()),
+            Error::AccessDenied(info) => ("AccessDenied".to_string(), info.to_string()),
+            Error::EntryNotFound(info) => ("EntryNotFound".to_string(), info.to_string()),
+            Error::EntryExists(info) => ("EntryExists".to_string(), info.to_string()),
+            Error::InvalidInput(info) => ("InvalidInput".to_string(), info.to_string()),
+            Error::InvalidAmount(info) => ("InvalidAmount".to_string(), info.to_string()),
+            Error::InvalidXorUrl(info) => ("InvalidXorUrl".to_string(), info.to_string()),
+            Error::InvalidMediaType(info) => ("InvalidMediaType".to_string(), info.to_string()),
+            Error::NotEnoughBalance(info) => ("NotEnoughBalance".to_string(), info.to_string()),
+            Error::FilesSystemError(info) => ("FilesSystemError".to_string(), info.to_string()),
+            Error::Unexpected(info) => ("Unexpected".to_string(), info.to_string()),
+            Error::Unknown(info) => ("Unknown".to_string(), info.to_string()),
+            Error::StringError(info) => ("StringError".to_string(), info.to_string()),
+        };
+        format!("[Error] {} - {}", error_type, error_msg)
+    }
+}
+
+impl ErrorCode for Error {
+    fn error_code(&self) -> i32 {
+        self.error_code()
     }
 }
 

--- a/safe-cli/subcommands/dog.rs
+++ b/safe-cli/subcommands/dog.rs
@@ -16,7 +16,7 @@ use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
 pub struct DogCommands {
-    /// The safe:// location to retrieve
+    /// The safe:// location to inspect
     location: Option<String>,
 }
 
@@ -30,7 +30,7 @@ pub fn dog_commander(
 
     // TODO: switch to connect_without_auth(safe)?;
     auth_connect(safe)?;
-    let content = safe.fetch(&url)?;
+    let content = safe.inspect(&url)?;
     match &content {
         SafeData::FilesContainer {
             xorurl,
@@ -41,7 +41,6 @@ pub fn dog_commander(
             resolved_from,
             ..
         } => {
-            // Render FilesContainer
             if OutputFmt::Pretty == output_fmt {
                 println!("Native data type: {}", data_type);
                 println!("Version: {}", version);
@@ -105,7 +104,6 @@ pub fn dog_commander(
             resolved_from,
             ..
         } => {
-            // Render Wallet
             if OutputFmt::Pretty == output_fmt {
                 println!("Native data type: {}", data_type);
                 println!("Type tag: {}", type_tag);

--- a/safe-ffi/ffi/fetch.rs
+++ b/safe-ffi/ffi/fetch.rs
@@ -3,7 +3,9 @@ use super::ffi_structs::{
     NrsMapContainerInfo, PublishedImmutableData, SafeKey, Wallet,
 };
 use super::{ResultReturn, Safe};
-use ffi_utils::{catch_unwind_cb, from_c_str, vec_into_raw_parts, FfiResult, OpaqueCtx};
+use ffi_utils::{
+    catch_unwind_cb, from_c_str, vec_into_raw_parts, FfiResult, NativeResult, OpaqueCtx,
+};
 use safe_api::fetch::SafeData;
 use std::ffi::CString;
 use std::os::raw::{c_char, c_void};
@@ -20,101 +22,154 @@ pub unsafe extern "C" fn fetch(
     o_err: extern "C" fn(user_data: *mut c_void, result: *const FfiResult),
 ) {
     catch_unwind_cb(user_data, o_err, || -> ResultReturn<()> {
-        let user_data = OpaqueCtx(user_data);
         let url = from_c_str(url)?;
-        let content = (*app).fetch(&url)?;
-        match &content {
-            SafeData::PublishedImmutableData {
-                xorurl,
-                data,
-                xorname,
-                resolved_from,
-                media_type,
-            } => {
-                let (data, data_len, data_cap) = vec_into_raw_parts(data.to_vec());
-                let published_data = PublishedImmutableData {
-                    xorurl: CString::new(xorurl.clone())?.into_raw(),
-                    xorname: xorname.0,
-                    data,
-                    data_len,
-                    data_cap,
-                    resolved_from: match resolved_from {
-                        Some(nrs_container_map) => {
-                            nrs_map_container_info_into_repr_c(&nrs_container_map)?
-                        }
-                        None => NrsMapContainerInfo::new()?,
-                    },
-                    media_type: CString::new(media_type.clone().unwrap())?.into_raw(),
-                };
-                o_published(user_data.0, &published_data);
-            }
-            SafeData::FilesContainer {
-                xorurl,
-                version,
-                files_map,
-                type_tag,
-                xorname,
-                data_type,
-                resolved_from,
-            } => {
-                let files_map_json = serde_json::to_string(&files_map)?;
-                let container = FilesContainer {
-                    xorurl: CString::new(xorurl.clone())?.into_raw(),
-                    version: *version,
-                    files_map: CString::new(files_map_json)?.into_raw(),
-                    type_tag: *type_tag,
-                    xorname: xorname.0,
-                    data_type: (*data_type).clone() as u64,
-                    resolved_from: match resolved_from {
-                        Some(nrs_container_map) => {
-                            nrs_map_container_info_into_repr_c(&nrs_container_map)?
-                        }
-                        None => NrsMapContainerInfo::new()?,
-                    },
-                };
-                o_container(user_data.0, &container);
-            }
-            SafeData::Wallet {
-                xorurl,
-                xorname,
-                type_tag,
-                balances,
-                data_type,
-                resolved_from,
-            } => {
-                let wallet = Wallet {
-                    xorurl: CString::new(xorurl.clone())?.into_raw(),
-                    xorname: xorname.0,
-                    type_tag: *type_tag,
-                    balances: wallet_spendable_balances_into_repr_c(balances)?,
-                    data_type: (*data_type).clone() as u64,
-                    resolved_from: match resolved_from {
-                        Some(nrs_container_map) => {
-                            nrs_map_container_info_into_repr_c(&nrs_container_map)?
-                        }
-                        None => NrsMapContainerInfo::new()?,
-                    },
-                };
-                o_wallet(user_data.0, &wallet);
-            }
-            SafeData::SafeKey {
-                xorurl,
-                xorname,
-                resolved_from,
-            } => {
-                let keys = SafeKey {
-                    xorurl: CString::new(xorurl.clone())?.into_raw(),
-                    xorname: xorname.0,
-                    resolved_from: match resolved_from {
-                        Some(nrs_container_map) => {
-                            nrs_map_container_info_into_repr_c(&nrs_container_map)?
-                        }
-                        None => NrsMapContainerInfo::new()?,
-                    },
-                };
-                o_keys(user_data.0, &keys);
-            }
-        };
-        Ok(())
+        let content = (*app).fetch(&url);
+        invoke_callback(
+            content,
+            user_data,
+            o_published,
+            o_wallet,
+            o_keys,
+            o_container,
+            o_err,
+        )
     })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn inspect(
+    app: *mut Safe,
+    url: *const c_char,
+    user_data: *mut c_void,
+    o_published: extern "C" fn(user_data: *mut c_void, *const PublishedImmutableData),
+    o_wallet: extern "C" fn(user_data: *mut c_void, *const Wallet),
+    o_keys: extern "C" fn(user_data: *mut c_void, *const SafeKey),
+    o_container: extern "C" fn(user_data: *mut c_void, *const FilesContainer),
+    o_err: extern "C" fn(user_data: *mut c_void, result: *const FfiResult),
+) {
+    catch_unwind_cb(user_data, o_err, || -> ResultReturn<()> {
+        let url = from_c_str(url)?;
+        let content = (*app).inspect(&url);
+        invoke_callback(
+            content,
+            user_data,
+            o_published,
+            o_wallet,
+            o_keys,
+            o_container,
+            o_err,
+        )
+    })
+}
+
+unsafe fn invoke_callback(
+    content: ResultReturn<SafeData>,
+    user_data: *mut c_void,
+    o_published: extern "C" fn(user_data: *mut c_void, *const PublishedImmutableData),
+    o_wallet: extern "C" fn(user_data: *mut c_void, *const Wallet),
+    o_keys: extern "C" fn(user_data: *mut c_void, *const SafeKey),
+    o_container: extern "C" fn(user_data: *mut c_void, *const FilesContainer),
+    o_err: extern "C" fn(user_data: *mut c_void, result: *const FfiResult),
+) -> ResultReturn<()> {
+    let user_data = OpaqueCtx(user_data);
+    match &content {
+        Ok(SafeData::PublishedImmutableData {
+            xorurl,
+            data,
+            xorname,
+            resolved_from,
+            media_type,
+        }) => {
+            let (data, data_len, data_cap) = vec_into_raw_parts(data.to_vec());
+            let published_data = PublishedImmutableData {
+                xorurl: CString::new(xorurl.clone())?.into_raw(),
+                xorname: xorname.0,
+                data,
+                data_len,
+                data_cap,
+                resolved_from: match resolved_from {
+                    Some(nrs_container_map) => {
+                        nrs_map_container_info_into_repr_c(&nrs_container_map)?
+                    }
+                    None => NrsMapContainerInfo::new()?,
+                },
+                media_type: CString::new(media_type.clone().unwrap())?.into_raw(),
+            };
+            o_published(user_data.0, &published_data);
+        }
+        Ok(SafeData::FilesContainer {
+            xorurl,
+            version,
+            files_map,
+            type_tag,
+            xorname,
+            data_type,
+            resolved_from,
+        }) => {
+            let files_map_json = serde_json::to_string(&files_map)?;
+            let container = FilesContainer {
+                xorurl: CString::new(xorurl.clone())?.into_raw(),
+                version: *version,
+                files_map: CString::new(files_map_json)?.into_raw(),
+                type_tag: *type_tag,
+                xorname: xorname.0,
+                data_type: (*data_type).clone() as u64,
+                resolved_from: match resolved_from {
+                    Some(nrs_container_map) => {
+                        nrs_map_container_info_into_repr_c(&nrs_container_map)?
+                    }
+                    None => NrsMapContainerInfo::new()?,
+                },
+            };
+            o_container(user_data.0, &container);
+        }
+        Ok(SafeData::Wallet {
+            xorurl,
+            xorname,
+            type_tag,
+            balances,
+            data_type,
+            resolved_from,
+        }) => {
+            let wallet = Wallet {
+                xorurl: CString::new(xorurl.clone())?.into_raw(),
+                xorname: xorname.0,
+                type_tag: *type_tag,
+                balances: wallet_spendable_balances_into_repr_c(balances)?,
+                data_type: (*data_type).clone() as u64,
+                resolved_from: match resolved_from {
+                    Some(nrs_container_map) => {
+                        nrs_map_container_info_into_repr_c(&nrs_container_map)?
+                    }
+                    None => NrsMapContainerInfo::new()?,
+                },
+            };
+            o_wallet(user_data.0, &wallet);
+        }
+        Ok(SafeData::SafeKey {
+            xorurl,
+            xorname,
+            resolved_from,
+        }) => {
+            let keys = SafeKey {
+                xorurl: CString::new(xorurl.clone())?.into_raw(),
+                xorname: xorname.0,
+                resolved_from: match resolved_from {
+                    Some(nrs_container_map) => {
+                        nrs_map_container_info_into_repr_c(&nrs_container_map)?
+                    }
+                    None => NrsMapContainerInfo::new()?,
+                },
+            };
+            o_keys(user_data.0, &keys);
+        }
+        Err(err) => {
+            let ffi_result = NativeResult {
+                error_code: err.error_code(),
+                description: Some(err.description()),
+            };
+            o_err(user_data.0, &ffi_result.into_repr_c()?);
+        }
+    };
+    Ok(())
 }


### PR DESCRIPTION
This adds a new `inspect` API, and the CLI `dog` command is simply switched to make use of it instead of using `fetch` API.