### PR TITLE
chore(ci): only clean for prod build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -278,7 +278,9 @@ def retrieveCache(os) {
 }
 
 def runReleaseBuild(component, type, target) {
-    def cleanBuild = env.BRANCH_NAME == "${params.CLEAN_BUILD_BRANCH}"
+    // Running a dev build as a clean build is very slow if we're trying to do
+    // both the prod and dev builds as part of the same job.
+    def cleanBuild = env.BRANCH_NAME == "${params.CLEAN_BUILD_BRANCH}" && type != "dev"
     withEnv(["SAFE_CLI_BUILD_COMPONENT=${component}",
              "SAFE_CLI_BUILD_TYPE=${type}",
              "SAFE_CLI_BUILD_CLEAN=${cleanBuild}",


### PR DESCRIPTION
I always like to do a release build (as in something we're going to
release to the public) as a clean build, just to ensure that no issues
with caching creep in, but it's very slow to do both the prod and the
dev builds as clean. Even though we will release the dev builds to the
public, it seems an acceptable risk to not run this as a clean build.
