### PR TITLE
refactor/error: rename ResultReturn to simply Result

### DIFF
--- a/safe-api/src/api/auth.rs
+++ b/safe-api/src/api/auth.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::helpers::decode_ipc_msg;
-use super::{Error, ResultReturn, Safe, SafeApp};
+use super::{Error, Result, Safe, SafeApp};
 use log::{debug, info};
 #[cfg(not(any(target_os = "android", target_os = "androideabi", target_os = "ios")))]
 use reqwest::get as httpget;
@@ -34,7 +34,7 @@ impl Safe {
         app_name: &str,
         app_vendor: &str,
         port: Option<u16>,
-    ) -> ResultReturn<String> {
+    ) -> Result<String> {
         info!("Sending authorisation request to SAFE Authenticator...");
 
         let req = IpcReq::Auth(AuthReq {
@@ -101,7 +101,7 @@ impl Safe {
     }
 
     // Connect to the SAFE Network using the provided app id and auth credentials
-    pub fn connect(&mut self, app_id: &str, auth_credentials: Option<&str>) -> ResultReturn<()> {
+    pub fn connect(&mut self, app_id: &str, auth_credentials: Option<&str>) -> Result<()> {
         self.safe_app.connect(app_id, auth_credentials)
     }
 }

--- a/safe-api/src/api/errors.rs
+++ b/safe-api/src/api/errors.rs
@@ -9,9 +9,9 @@
 use self::codes::*;
 use std::fmt;
 
-pub type ResultReturn<T> = Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Error {
     AuthError(String),
     ConnectionError(String),

--- a/safe-api/src/api/fetch.rs
+++ b/safe-api/src/api/fetch.rs
@@ -11,7 +11,7 @@ use super::helpers::get_subnames_host_path_and_version;
 use super::nrs_map::NrsMap;
 pub use super::wallet::WalletSpendableBalances;
 pub use super::xorurl::{SafeContentType, SafeDataType, XorUrlEncoder};
-use super::{Error, ResultReturn, Safe, XorName};
+use super::{Error, Result, Safe, XorName};
 use log::{debug, info};
 use serde::{Deserialize, Serialize};
 
@@ -90,7 +90,7 @@ impl Safe {
     ///
     /// assert!(data_string.starts_with("hello tests!"));
     /// ```
-    pub fn fetch(&self, url: &str) -> ResultReturn<SafeData> {
+    pub fn fetch(&self, url: &str) -> Result<SafeData> {
         fetch_from_url(self, url, true)
     }
 
@@ -127,12 +127,12 @@ impl Safe {
     ///
     /// assert!(data_string.starts_with("hello tests!"));
     /// ```
-    pub fn inspect(&self, url: &str) -> ResultReturn<SafeData> {
+    pub fn inspect(&self, url: &str) -> Result<SafeData> {
         fetch_from_url(self, url, false)
     }
 }
 
-pub fn fetch_from_url(safe: &Safe, url: &str, retrieve_data: bool) -> ResultReturn<SafeData> {
+pub fn fetch_from_url(safe: &Safe, url: &str, retrieve_data: bool) -> Result<SafeData> {
     let mut the_xor = Safe::parse_url(url)?;
     let xorurl = the_xor.to_string()?;
     info!("URL parsed successfully, fetching: {}", xorurl);
@@ -317,7 +317,7 @@ pub fn fetch_from_url(safe: &Safe, url: &str, retrieve_data: bool) -> ResultRetu
 fn embed_resolved_from(
     content: SafeData,
     nrs_map_container: NrsMapContainerInfo,
-) -> ResultReturn<SafeData> {
+) -> Result<SafeData> {
     let safe_data = match content {
         SafeData::SafeKey {
             xorurl, xorname, ..

--- a/safe-api/src/api/helpers.rs
+++ b/safe-api/src/api/helpers.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{Error, ResultReturn};
+use super::{Error, Result};
 use chrono::{SecondsFormat, Utc};
 
 use log::debug;
@@ -39,7 +39,7 @@ impl KeyPair {
     }
 
     #[allow(dead_code)]
-    pub fn from_hex_keys(pk_hex_str: &str, sk_hex_str: &str) -> ResultReturn<Self> {
+    pub fn from_hex_keys(pk_hex_str: &str, sk_hex_str: &str) -> Result<Self> {
         let pk = pk_from_hex(pk_hex_str)?;
         let sk = sk_from_hex(sk_hex_str)?;
         if pk != sk.public_key() {
@@ -51,13 +51,13 @@ impl KeyPair {
         }
     }
 
-    pub fn from_hex_sk(sk_hex_str: &str) -> ResultReturn<Self> {
+    pub fn from_hex_sk(sk_hex_str: &str) -> Result<Self> {
         let sk = sk_from_hex(sk_hex_str)?;
         let pk = sk.public_key();
         Ok(KeyPair { pk, sk })
     }
 
-    pub fn to_hex_key_pair(&self) -> ResultReturn<(String, String)> {
+    pub fn to_hex_key_pair(&self) -> Result<(String, String)> {
         let pk: String = pk_to_hex(&self.pk);
 
         let sk_serialised = bincode::serialize(&SerdeSecret(&self.sk))
@@ -112,7 +112,7 @@ pub fn pk_to_hex(pk: &PublicKey) -> String {
     vec_to_hex(pk_as_bytes.to_vec())
 }
 
-pub fn pk_from_hex(hex_str: &str) -> ResultReturn<PublicKey> {
+pub fn pk_from_hex(hex_str: &str) -> Result<PublicKey> {
     let pk_bytes = parse_hex(&hex_str);
     let mut pk_bytes_array: [u8; PK_SIZE] = [0; PK_SIZE];
     pk_bytes_array.copy_from_slice(&pk_bytes[..PK_SIZE]);
@@ -120,13 +120,13 @@ pub fn pk_from_hex(hex_str: &str) -> ResultReturn<PublicKey> {
         .map_err(|_| Error::InvalidInput("Invalid public key bytes".to_string()))
 }
 
-pub fn sk_from_hex(hex_str: &str) -> ResultReturn<SecretKey> {
+pub fn sk_from_hex(hex_str: &str) -> Result<SecretKey> {
     let sk_bytes = parse_hex(&hex_str);
     bincode::deserialize(&sk_bytes)
         .map_err(|_| Error::InvalidInput("Failed to deserialize provided secret key".to_string()))
 }
 
-pub fn parse_coins_amount(amount_str: &str) -> ResultReturn<Coins> {
+pub fn parse_coins_amount(amount_str: &str) -> Result<Coins> {
     Coins::from_str(amount_str).map_err(|err| {
         match err {
             SafeNdError::ExcessiveValue => Error::InvalidAmount(format!(
@@ -144,7 +144,7 @@ pub fn parse_coins_amount(amount_str: &str) -> ResultReturn<Coins> {
     })
 }
 
-pub fn decode_ipc_msg(ipc_msg: &str) -> ResultReturn<AuthGranted> {
+pub fn decode_ipc_msg(ipc_msg: &str) -> Result<AuthGranted> {
     let msg = decode_msg(&ipc_msg)
         .map_err(|e| Error::InvalidInput(format!("Failed to decode the credentials: {:?}", e)))?;
     match msg {
@@ -159,7 +159,7 @@ pub fn decode_ipc_msg(ipc_msg: &str) -> ResultReturn<AuthGranted> {
 
 pub fn get_subnames_host_path_and_version(
     xorurl: &str,
-) -> ResultReturn<(Vec<String>, String, String, Option<u64>)> {
+) -> Result<(Vec<String>, String, String, Option<u64>)> {
     let parsing_url = Url::parse(&xorurl).map_err(|parse_err| {
         Error::InvalidXorUrl(format!(
             "Problem parsing the safe:// URL \"{}\": {}",

--- a/safe-api/src/api/mod.rs
+++ b/safe-api/src/api/mod.rs
@@ -24,7 +24,7 @@ pub mod wallet;
 pub mod xorurl;
 mod xorurl_media_types;
 
-pub use errors::{Error, ResultReturn};
+pub use errors::{Error, Result};
 pub use fetch::{
     NrsMapContainerInfo, SafeContentType, SafeData, SafeDataType, WalletSpendableBalances,
 };

--- a/safe-api/src/api/nrs_map.rs
+++ b/safe-api/src/api/nrs_map.rs
@@ -10,7 +10,7 @@ use super::constants::{
     FAKE_RDF_PREDICATE_CREATED, FAKE_RDF_PREDICATE_LINK, FAKE_RDF_PREDICATE_MODIFIED,
 };
 use super::helpers::gen_timestamp_secs;
-use super::{Error, ResultReturn, Safe, SafeContentType, XorUrl};
+use super::{Error, Result, Safe, SafeContentType, XorUrl};
 use log::{debug, info};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -70,11 +70,11 @@ pub struct NrsMap {
 }
 
 impl NrsMap {
-    pub fn get_default(&self) -> ResultReturn<&DefaultRdf> {
+    pub fn get_default(&self) -> Result<&DefaultRdf> {
         Ok(&self.default)
     }
 
-    pub fn resolve_for_subnames(&self, mut sub_names: Vec<SubName>) -> ResultReturn<XorUrl> {
+    pub fn resolve_for_subnames(&self, mut sub_names: Vec<SubName>) -> Result<XorUrl> {
         debug!("NRS: Attempting to resolve for subnames {:?}", sub_names);
         let mut nrs_map = self;
         let dereferenced_link: String;
@@ -153,7 +153,7 @@ impl NrsMap {
     }
 
     #[allow(dead_code)]
-    pub fn get_default_link(&self) -> ResultReturn<XorUrl> {
+    pub fn get_default_link(&self) -> Result<XorUrl> {
         debug!("Attempting to get default link vis NRS....");
         let dereferenced_link: String;
         let link = match &self.default {
@@ -184,7 +184,7 @@ impl NrsMap {
         Ok(link.to_string())
     }
 
-    pub fn nrs_map_remove_subname(&mut self, name: &str) -> ResultReturn<String> {
+    pub fn nrs_map_remove_subname(&mut self, name: &str) -> Result<String> {
         info!("Removing sub name \"{}\" from NRS map", name);
         let sub_names = parse_nrs_name(name)?;
 
@@ -202,7 +202,7 @@ impl NrsMap {
         link: &str,
         default: bool,
         hard_link: bool,
-    ) -> ResultReturn<String> {
+    ) -> Result<String> {
         info!("Updating NRS map for: {}", name);
 
         // NRS resolver doesn't allow unversioned links
@@ -231,7 +231,7 @@ impl NrsMap {
     }
 
     #[allow(dead_code)]
-    pub fn get_link_for(&self, sub_name: &str) -> ResultReturn<XorUrl> {
+    pub fn get_link_for(&self, sub_name: &str) -> Result<XorUrl> {
         let the_entry = self.sub_names_map.get(sub_name);
 
         let link = match the_entry {
@@ -260,7 +260,7 @@ impl NrsMap {
     }
 }
 
-fn create_public_name_description(link: &str) -> ResultReturn<DefinitionData> {
+fn create_public_name_description(link: &str) -> Result<DefinitionData> {
     let now = gen_timestamp_secs();
     let mut public_name = DefinitionData::new();
     public_name.insert(FAKE_RDF_PREDICATE_LINK.to_string(), link.to_string());
@@ -288,7 +288,7 @@ fn sub_names_vec_to_str(sub_names: &[SubName]) -> String {
     }
 }
 
-fn parse_nrs_name(name: &str) -> ResultReturn<Vec<String>> {
+fn parse_nrs_name(name: &str) -> Result<Vec<String>> {
     // santize to a simple string
     let sanitized_name = str::replace(&name, "safe://", "").to_string();
 
@@ -301,7 +301,7 @@ fn parse_nrs_name(name: &str) -> ResultReturn<Vec<String>> {
     Ok(sub_names)
 }
 
-fn validate_nrs_link(link: &str) -> ResultReturn<()> {
+fn validate_nrs_link(link: &str) -> Result<()> {
     let link_encoder = Safe::parse_url(link)?;
     if link_encoder.content_version().is_none() {
         // We could try to automatically set the latest/current version,
@@ -324,7 +324,7 @@ fn setup_nrs_tree(
     nrs_map: &NrsMap,
     mut sub_names: Vec<String>,
     link: &str,
-) -> ResultReturn<NrsMap> {
+) -> Result<NrsMap> {
     let mut updated_nrs_map = nrs_map.clone();
     let curr_sub_name = if sub_names.is_empty() {
         let definition_data = create_public_name_description(link)?;
@@ -370,7 +370,7 @@ fn setup_nrs_tree(
 fn remove_nrs_sub_tree(
     nrs_map: &NrsMap,
     mut sub_names: Vec<String>,
-) -> ResultReturn<(NrsMap, String)> {
+) -> Result<(NrsMap, String)> {
     let mut updated_nrs_map = nrs_map.clone();
     let curr_sub_name = if sub_names.is_empty() {
         match nrs_map.get_default()? {

--- a/safe-api/src/api/safe_net.rs
+++ b/safe-api/src/api/safe_net.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::errors::ResultReturn;
+use super::errors::Result;
 use safe_nd::{Coins, MDataSeqValue, SeqMutableData, Transaction, TransactionId, XorName};
 use std::collections::BTreeMap;
 use threshold_crypto::{PublicKey, SecretKey};
@@ -16,18 +16,18 @@ pub type AppendOnlyDataRawData = (Vec<u8>, Vec<u8>);
 pub trait SafeApp {
     fn new() -> Self;
 
-    fn connect(&mut self, app_id: &str, auth_credentials: Option<&str>) -> ResultReturn<()>;
+    fn connect(&mut self, app_id: &str, auth_credentials: Option<&str>) -> Result<()>;
 
     fn create_balance(
         &mut self,
         from_sk: Option<SecretKey>,
         new_balance_owner: PublicKey,
         amount: Coins,
-    ) -> ResultReturn<XorName>;
+    ) -> Result<XorName>;
 
-    fn allocate_test_coins(&mut self, owner_sk: SecretKey, amount: Coins) -> ResultReturn<XorName>;
+    fn allocate_test_coins(&mut self, owner_sk: SecretKey, amount: Coins) -> Result<XorName>;
 
-    fn get_balance_from_sk(&self, sk: SecretKey) -> ResultReturn<Coins>;
+    fn get_balance_from_sk(&self, sk: SecretKey) -> Result<Coins>;
 
     fn safecoin_transfer_to_xorname(
         &mut self,
@@ -35,7 +35,7 @@ pub trait SafeApp {
         to_xorname: XorName,
         tx_id: TransactionId,
         amount: Coins,
-    ) -> ResultReturn<Transaction>;
+    ) -> Result<Transaction>;
 
     fn safecoin_transfer_to_pk(
         &mut self,
@@ -43,13 +43,13 @@ pub trait SafeApp {
         to_pk: PublicKey,
         tx_id: TransactionId,
         amount: Coins,
-    ) -> ResultReturn<Transaction>;
+    ) -> Result<Transaction>;
 
-    fn get_transaction(&self, tx_id: u64, pk: PublicKey, sk: SecretKey) -> ResultReturn<String>;
+    fn get_transaction(&self, tx_id: u64, pk: PublicKey, sk: SecretKey) -> Result<String>;
 
-    fn files_put_published_immutable(&mut self, data: &[u8]) -> ResultReturn<XorName>;
+    fn files_put_published_immutable(&mut self, data: &[u8]) -> Result<XorName>;
 
-    fn files_get_published_immutable(&self, xorname: XorName) -> ResultReturn<Vec<u8>>;
+    fn files_get_published_immutable(&self, xorname: XorName) -> Result<Vec<u8>>;
 
     fn put_seq_append_only_data(
         &mut self,
@@ -57,7 +57,7 @@ pub trait SafeApp {
         name: Option<XorName>,
         tag: u64,
         permissions: Option<String>,
-    ) -> ResultReturn<XorName>;
+    ) -> Result<XorName>;
 
     fn append_seq_append_only_data(
         &mut self,
@@ -65,26 +65,26 @@ pub trait SafeApp {
         new_version: u64,
         name: XorName,
         tag: u64,
-    ) -> ResultReturn<u64>;
+    ) -> Result<u64>;
 
     fn get_latest_seq_append_only_data(
         &self,
         name: XorName,
         tag: u64,
-    ) -> ResultReturn<(u64, AppendOnlyDataRawData)>;
+    ) -> Result<(u64, AppendOnlyDataRawData)>;
 
     fn get_current_seq_append_only_data_version(
         &self,
         name: XorName,
         tag: u64,
-    ) -> ResultReturn<u64>;
+    ) -> Result<u64>;
 
     fn get_seq_append_only_data(
         &self,
         name: XorName,
         tag: u64,
         version: u64,
-    ) -> ResultReturn<AppendOnlyDataRawData>;
+    ) -> Result<AppendOnlyDataRawData>;
 
     fn put_seq_mutable_data(
         &mut self,
@@ -92,9 +92,9 @@ pub trait SafeApp {
         tag: u64,
         // data: Option<String>,
         permissions: Option<String>,
-    ) -> ResultReturn<XorName>;
+    ) -> Result<XorName>;
 
-    fn get_seq_mdata(&self, name: XorName, tag: u64) -> ResultReturn<SeqMutableData>;
+    fn get_seq_mdata(&self, name: XorName, tag: u64) -> Result<SeqMutableData>;
 
     fn seq_mutable_data_insert(
         &mut self,
@@ -102,20 +102,20 @@ pub trait SafeApp {
         tag: u64,
         key: &[u8],
         value: &[u8],
-    ) -> ResultReturn<()>;
+    ) -> Result<()>;
 
     fn seq_mutable_data_get_value(
         &self,
         name: XorName,
         tag: u64,
         key: &[u8],
-    ) -> ResultReturn<MDataSeqValue>;
+    ) -> Result<MDataSeqValue>;
 
     fn list_seq_mdata_entries(
         &self,
         name: XorName,
         tag: u64,
-    ) -> ResultReturn<BTreeMap<Vec<u8>, MDataSeqValue>>;
+    ) -> Result<BTreeMap<Vec<u8>, MDataSeqValue>>;
 
     fn seq_mutable_data_update(
         &mut self,
@@ -124,5 +124,5 @@ pub trait SafeApp {
         key: &[u8],
         value: &[u8],
         version: u64,
-    ) -> ResultReturn<()>;
+    ) -> Result<()>;
 }

--- a/safe-api/src/api/wallet.rs
+++ b/safe-api/src/api/wallet.rs
@@ -8,7 +8,7 @@
 
 use super::helpers::{parse_coins_amount, sk_from_hex, xorname_from_pk, xorname_to_hex, KeyPair};
 use super::xorurl::{SafeContentType, SafeDataType};
-use super::{Error, ResultReturn, Safe, SafeApp, XorUrl, XorUrlEncoder};
+use super::{Error, Result, Safe, SafeApp, XorUrl, XorUrlEncoder};
 use log::debug;
 use rand_core::RngCore;
 use safe_nd::{Coins, XorName};
@@ -32,7 +32,7 @@ pub type WalletSpendableBalances = BTreeMap<String, (bool, WalletSpendableBalanc
 #[allow(dead_code)]
 impl Safe {
     // Create an empty Wallet and return its XOR-URL
-    pub fn wallet_create(&mut self) -> ResultReturn<XorUrl> {
+    pub fn wallet_create(&mut self) -> Result<XorUrl> {
         let xorname = self
             .safe_app
             .put_seq_mutable_data(None, WALLET_TYPE_TAG, None)?;
@@ -56,7 +56,7 @@ impl Safe {
         name: Option<&str>,
         default: bool,
         sk: &str,
-    ) -> ResultReturn<String> {
+    ) -> Result<String> {
         let key_pair = KeyPair::from_hex_sk(sk)?;
         let xorname = xorname_from_pk(key_pair.pk);
         let xorurl = XorUrlEncoder::encode(
@@ -130,7 +130,7 @@ impl Safe {
     }
 
     // Check the total balance of a Wallet found at a given XOR-URL
-    pub fn wallet_balance(&mut self, url: &str) -> ResultReturn<String> {
+    pub fn wallet_balance(&mut self, url: &str) -> Result<String> {
         debug!("Finding total wallet balance for: {:?}", url);
         let mut total_balance = Coins::from_nano(0).map_err(|err| {
             Error::Unexpected(format!(
@@ -204,7 +204,7 @@ impl Safe {
     pub fn wallet_get_default_balance(
         &self,
         url: &str,
-    ) -> ResultReturn<(WalletSpendableBalance, u64)> {
+    ) -> Result<(WalletSpendableBalance, u64)> {
         let (xorurl_encoder, _) = self.parse_and_resolve_url(url)?;
         let default = self
             .safe_app
@@ -272,7 +272,7 @@ impl Safe {
         from_url: Option<&str>,
         to_url: &str,
         tx_id: Option<u64>,
-    ) -> ResultReturn<u64> {
+    ) -> Result<u64> {
         // Parse and validate the amount is a valid
         let amount_coins = parse_coins_amount(amount)?;
 
@@ -356,7 +356,7 @@ impl Safe {
         }
     }
 
-    pub fn wallet_get(&self, url: &str) -> ResultReturn<WalletSpendableBalances> {
+    pub fn wallet_get(&self, url: &str) -> Result<WalletSpendableBalances> {
         let (xorurl_encoder, _) = self.parse_and_resolve_url(url)?;
         gen_wallet_spendable_balances_list(&self, xorurl_encoder.xorname(), url)
     }
@@ -367,7 +367,7 @@ fn gen_wallet_spendable_balances_list(
     safe: &Safe,
     xorname: XorName,
     url: &str,
-) -> ResultReturn<WalletSpendableBalances> {
+) -> Result<WalletSpendableBalances> {
     let entries = match safe
         .safe_app
         .list_seq_mdata_entries(xorname, WALLET_TYPE_TAG)
@@ -429,7 +429,7 @@ fn wallet_get_spendable_balance(
     safe: &Safe,
     xorname: XorName,
     balance_name: &[u8],
-) -> ResultReturn<(WalletSpendableBalance, u64)> {
+) -> Result<(WalletSpendableBalance, u64)> {
     let the_balance: (WalletSpendableBalance, u64) = {
         let default_balance_vec = safe
             .safe_app
@@ -458,7 +458,7 @@ fn resolve_wallet_url(
     wallet_url: &str,
     xorurl_encoder: XorUrlEncoder,
     nrs_xorurl_encoder: Option<XorUrlEncoder>,
-) -> ResultReturn<WalletSpendableBalance> {
+) -> Result<WalletSpendableBalance> {
     let url_path = if let Some(nrs_url) = nrs_xorurl_encoder {
         nrs_url.path().to_string()
     } else {

--- a/safe-api/src/api/xorurl.rs
+++ b/safe-api/src/api/xorurl.rs
@@ -8,7 +8,7 @@
 
 use super::helpers::get_subnames_host_path_and_version;
 use super::xorurl_media_types::{MEDIA_TYPE_CODES, MEDIA_TYPE_STR};
-use super::{Error, ResultReturn};
+use super::{Error, Result};
 use log::debug;
 use multibase::{decode, encode, Base};
 use safe_nd::{XorName, XOR_NAME_LEN};
@@ -42,7 +42,7 @@ impl std::fmt::Display for SafeContentType {
 
 impl SafeContentType {
     #[allow(dead_code)]
-    pub fn from_u16(value: u16) -> ResultReturn<SafeContentType> {
+    pub fn from_u16(value: u16) -> Result<SafeContentType> {
         match value {
             0 => Ok(SafeContentType::Raw),
             1 => Ok(SafeContentType::Wallet),
@@ -53,7 +53,7 @@ impl SafeContentType {
     }
 
     #[allow(dead_code)]
-    pub fn value(&self) -> ResultReturn<u16> {
+    pub fn value(&self) -> Result<u16> {
         match &*self {
             SafeContentType::Raw => Ok(0),
             SafeContentType::Wallet => Ok(1),
@@ -91,7 +91,7 @@ impl std::fmt::Display for SafeDataType {
 
 impl SafeDataType {
     #[allow(dead_code)]
-    pub fn from_u64(value: u64) -> ResultReturn<SafeDataType> {
+    pub fn from_u64(value: u64) -> Result<SafeDataType> {
         match value {
             0 => Ok(SafeDataType::SafeKey),
             1 => Ok(SafeDataType::PublishedImmutableData),
@@ -128,7 +128,7 @@ impl XorUrlEncoder {
         path: Option<&str>,
         sub_names: Option<Vec<String>>,
         content_version: Option<u64>,
-    ) -> ResultReturn<Self> {
+    ) -> Result<Self> {
         if let SafeContentType::MediaType(ref media_type) = content_type {
             if !XorUrlEncoder::is_media_type_supported(media_type) {
                 return Err(Error::InvalidMediaType(format!(
@@ -166,7 +166,7 @@ impl XorUrlEncoder {
         sub_names: Option<Vec<String>>,
         content_version: Option<u64>,
         base: &str,
-    ) -> ResultReturn<String> {
+    ) -> Result<String> {
         let xorurl_encoder = XorUrlEncoder::new(
             xorname,
             type_tag,
@@ -179,7 +179,7 @@ impl XorUrlEncoder {
         xorurl_encoder.to_base(base)
     }
 
-    pub fn from_url(xorurl: &str) -> ResultReturn<Self> {
+    pub fn from_url(xorurl: &str) -> Result<Self> {
         let (sub_names, cid_str, path, content_version) =
             get_subnames_host_path_and_version(&xorurl)?;
 
@@ -323,11 +323,11 @@ impl XorUrlEncoder {
     // 32 bytes for XoR Name
     // and up to 8 bytes for type_tag
     // query param "v=" is treated as the content version
-    pub fn to_string(&self) -> ResultReturn<String> {
+    pub fn to_string(&self) -> Result<String> {
         self.to_base("")
     }
 
-    pub fn to_base(&self, base: &str) -> ResultReturn<String> {
+    pub fn to_base(&self, base: &str) -> Result<String> {
         // let's set the first byte with the XOR-URL format version
         let mut cid_vec: Vec<u8> = vec![XOR_URL_VERSION_1 as u8];
 

--- a/safe-ffi/ffi/errors.rs
+++ b/safe-ffi/ffi/errors.rs
@@ -13,7 +13,7 @@ use std::fmt;
 
 pub type Result<T> = std::result::Result<T, FfiError>;
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct FfiError(Error);
 
 impl FfiError {

--- a/safe-ffi/ffi/fetch.rs
+++ b/safe-ffi/ffi/fetch.rs
@@ -5,7 +5,7 @@ use super::ffi_structs::{
 };
 use ffi_utils::{catch_unwind_cb, vec_into_raw_parts, FfiResult, NativeResult, OpaqueCtx, ReprC};
 use safe_api::fetch::SafeData;
-use safe_api::{ResultReturn, Safe};
+use safe_api::Safe;
 use std::ffi::CString;
 use std::os::raw::{c_char, c_void};
 
@@ -62,7 +62,7 @@ pub unsafe extern "C" fn inspect(
 }
 
 unsafe fn invoke_callback(
-    content: ResultReturn<SafeData>,
+    content: safe_api::Result<SafeData>,
     user_data: *mut c_void,
     o_published: extern "C" fn(user_data: *mut c_void, *const PublishedImmutableData),
     o_wallet: extern "C" fn(user_data: *mut c_void, *const Wallet),


### PR DESCRIPTION
Mostly this was a simple search/replace. This should reduce some verbosity.

Resolves #276 